### PR TITLE
Data: lines info endpoint

### DIFF
--- a/api/app/controllers/data_app.rb
+++ b/api/app/controllers/data_app.rb
@@ -1,0 +1,26 @@
+class DataApp < App
+  helpers CacheHelpers
+  helpers DataHelpers
+
+  use Rack::Cache,
+    :verbose     => true,
+    :metastore   => CACHE_CLIENT,
+    :entitystore => CACHE_CLIENT,
+    :private_headers => []
+
+  enable :logging
+
+  before do
+    cache_control :no_cache
+  end
+
+  get '/:url_name/lines' do |url_name|
+    @city = City[url_name: url_name]
+
+    halt 404 unless @city
+
+    last_modified last_modified_base_data(@city)
+
+    city_lines_data(@city).to_json
+  end
+end

--- a/api/app/controllers/data_app.rb
+++ b/api/app/controllers/data_app.rb
@@ -14,13 +14,13 @@ class DataApp < App
     cache_control :no_cache
   end
 
-  get '/:url_name/lines' do |url_name|
+  get '/:url_name/lines_systems_and_modes' do |url_name|
     @city = City[url_name: url_name]
 
     halt 404 unless @city
 
     last_modified last_modified_base_data(@city)
 
-    city_lines_data(@city).to_json
+    city_lines_systems_and_modes(@city).to_json
   end
 end

--- a/api/app/helpers/data_helpers.rb
+++ b/api/app/helpers/data_helpers.rb
@@ -1,5 +1,5 @@
 module DataHelpers
-  def city_lines_data(city)
+  def city_lines_systems_and_modes(city)
     lines = city.lines.map do |line|
       transport_mode = line.transport_mode
       system = line.system

--- a/api/app/helpers/data_helpers.rb
+++ b/api/app/helpers/data_helpers.rb
@@ -4,10 +4,12 @@ module DataHelpers
       transport_mode = line.transport_mode
       system = line.system
       {
+        id: line.id,
         name: line.name,
         url_name: line.url_name,
         color: line.color,
-        system: system.name,
+        system_id: system.id,
+        system_name: system.name,
         transport_mode_id: transport_mode.id,
         transport_mode_name: transport_mode.name
       }

--- a/api/app/helpers/data_helpers.rb
+++ b/api/app/helpers/data_helpers.rb
@@ -1,0 +1,18 @@
+module DataHelpers
+  def city_lines_data(city)
+    lines = city.lines.map do |line|
+      transport_mode = line.transport_mode
+      system = line.system
+      {
+        name: line.name,
+        url_name: line.url_name,
+        color: line.color,
+        system: system.name,
+        transport_mode_id: transport_mode.id,
+        transport_mode_name: transport_mode.name
+      }
+    end
+
+    Naturally.sort_by(lines){|line| line[:name]}
+  end
+end

--- a/api/lib/feature_collection/station.rb
+++ b/api/lib/feature_collection/station.rb
@@ -42,11 +42,10 @@ module FeatureCollection
         left join lateral (
           select
             station_id,
-            json_agg(json_build_object('line',lines.name,'line_url_name',lines.url_name,'system',coalesce(systems.name,''),'transport_mode_name',transport_modes.name)) as lines
+            json_agg(json_build_object('line',lines.name,'line_url_name',lines.url_name,'system',coalesce(systems.name,''))) as lines
           from station_lines
             left join lines on lines.id = station_lines.line_id
             left join systems on systems.id = system_id
-            left join transport_modes on transport_modes.id = transport_mode_id
           where station_id = stations.id
           group by station_id
          ) as lines_data on station_id = stations.id

--- a/api/test/unit/helpers/data_helpers.rb
+++ b/api/test/unit/helpers/data_helpers.rb
@@ -1,0 +1,55 @@
+require File.expand_path '../../../test_config', __FILE__
+
+describe DataHelpers do
+  include DataHelpers
+
+  describe '#city_lines_systems_and_modes' do
+    let(:city)  { City.create(name: 'Stockholm', url_name: 'stockholm') }
+    let(:system) { System.create(name: 'Tunnelbana', city_id: city.id) }
+    let(:line1) {
+      Line.create(
+        name: 'L1',
+        color: 'red',city_id: city.id,
+        system_id: system.id,
+        transport_mode_id: 4,
+        url_name: 'l1'
+      )
+    }
+    let(:line2) {
+      Line.create(
+        name: 'L2',
+        color: 'green',
+        city_id: city.id,
+        system_id: system.id,
+        transport_mode_id: 5,
+        url_name: 'l2'
+      )
+    }
+
+    it "should return the city lines, systems and modes data sorted naturally" do
+      expected_line1 = {
+        id: line1.id,
+        name: 'L1',
+        url_name: 'l1',
+        color: 'red',
+        system_id: system.id,
+        system_name: 'Tunnelbana',
+        transport_mode_id: 4,
+        transport_mode_name: 'heavy_rail'
+      }
+
+      expected_line2 = {
+        id: line2.id,
+        name: 'L2',
+        url_name: 'l2',
+        color: 'green',
+        system_id: system.id,
+        system_name: 'Tunnelbana',
+        transport_mode_id: 5,
+        transport_mode_name: 'light_rail'
+      }
+
+      assert_equal [expected_line1, expected_line2], city_lines_systems_and_modes(city)
+    end
+  end
+end

--- a/api/test/unit/lib/feature_collection/station.rb
+++ b/api/test/unit/lib/feature_collection/station.rb
@@ -58,7 +58,7 @@ describe FeatureCollection::Station do
     assert_empty feature[:properties][:lines]
   end
 
-  it "formatted_feature should add width and buildstart_end to raw_feature, and remove osm fields" do
+  it "formatted_feature should add width, buildstart_end and transport_mode_name to raw_feature, and remove osm fields" do
     expected_feature = FeatureCollection::Station.by_feature(@station.id).first
     expected_feature[:properties].merge!(
       width: @line.width,
@@ -66,6 +66,8 @@ describe FeatureCollection::Station do
       buildstart_end: @station.opening,
       line_url_name: @station.lines.first.url_name,
     ).reject!{|f| [:osm_tags, :osm_id, :osm_metadata].include?(f)}
+
+    expected_feature[:properties][:lines].first[:transport_mode_name] = @line.transport_mode[:name]
 
     formatted_feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
     assert_equal expected_feature, formatted_feature
@@ -81,7 +83,6 @@ describe FeatureCollection::Station do
       line: @line.name,
       line_url_name: @line.url_name,
       system: @system.name,
-      transport_mode_name: @line.transport_mode[:name]
     }]
 
     expected_properties = {id: @station.id,

--- a/client/src/components/city-data.js
+++ b/client/src/components/city-data.js
@@ -43,7 +43,14 @@ class CityData extends Component {
 
   currentCityLink(type) {
     const urlName = this.state.city.substr(1);
-    const url = `/api/${urlName}/raw_source/${type}`;
+
+    let url;
+    if (type == 'lines_systems_and_modes') {
+      url = `/api/data/${urlName}/${type}`;
+    } else {
+      url = `/api/${urlName}/raw_source/${type}`;
+    }
+
     const label = `${urlName}_${type}.geojson`;
 
     return {
@@ -80,7 +87,7 @@ class CityData extends Component {
         { this.currentCity() &&
           <div>
             {
-              ['sections', 'stations' ].map(type =>
+              ['sections', 'stations', 'lines_systems_and_modes'].map(type =>
                 <p key={this.currentCityLink(type).label}>
                   <a
                     className="c-link"

--- a/client/src/components/city-data.js
+++ b/client/src/components/city-data.js
@@ -45,13 +45,17 @@ class CityData extends Component {
     const urlName = this.state.city.substr(1);
 
     let url;
+    let extension;
+
     if (type == 'lines_systems_and_modes') {
+      extension = 'json';
       url = `/api/data/${urlName}/${type}`;
     } else {
+      extension = 'geojson';
       url = `/api/${urlName}/raw_source/${type}`;
     }
 
-    const label = `${urlName}_${type}.geojson`;
+    const label = `${urlName}_${type}.${extension}`;
 
     return {
       url: url,

--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,7 @@ require File.join(File.dirname(__FILE__), "api", "config", "app")
 require File.join(File.dirname(__FILE__), "api", "app", "controllers", "base_app")
 require File.join(File.dirname(__FILE__), "api", "app", "controllers", "api")
 require File.join(File.dirname(__FILE__), "api", "app", "controllers", "auth")
+require File.join(File.dirname(__FILE__), "api", "app", "controllers", "data_app")
 
 $stdout.sync = true
 
@@ -16,4 +17,8 @@ end
 
 map "/api/auth" do
   run Auth.new
+end
+
+map "/api/data" do
+  run DataApp.new
 end


### PR DESCRIPTION
This endpoint can be used by citylines2osm to add transport mode tags.

Remaining tasks:
- [x] Tests
- [x] Link in Data page