### PR TITLE
Dynamic lines for sections and stations

### DIFF
--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -163,7 +163,6 @@ class Api < App
   end
 
   get '/popup/:features' do |features|
-    # FIXME: right now only sections
     {featuresData: popup_features_data(features)}.to_json
   end
 end

--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -172,7 +172,6 @@ class Api < App
     features_data = Section.where(id: section_ids).all.map do |section|
       lines = section.section_lines.map do |sl|
         line = sl.line
-        # FIXME: add colors
         {
           name: line.name,
           url_name: line.url_name,

--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -164,35 +164,6 @@ class Api < App
 
   get '/popup/:features' do |features|
     # FIXME: right now only sections
-    section_ids = features.split(',').map do |f|
-      f_parts = f.split('-')
-      f_parts.last if f_parts.first == 'Section'
-    end.compact
-
-    features_data = Section.where(id: section_ids).all.map do |section|
-      lines = section.section_lines.map do |sl|
-        line = sl.line
-        {
-          name: line.name,
-          url_name: line.url_name,
-          system: line.system.name,
-          transport_mode_name: line.transport_mode.name,
-          color: line.color,
-          label_font_color: line_label_font_color(line.color),
-          from: sl.fromyear,
-          to: sl.toyear
-        }
-      end
-
-      {
-        buildstart: section.buildstart,
-        buildstart_end: section.opening || section.closure || FeatureCollection::Section::FUTURE,
-        section_closure: section.closure || FeatureCollection::Section::FUTURE,
-        length: section.length,
-        lines: lines
-      }
-    end
-
-    {featuresData: features_data}.to_json
+    {featuresData: popup_features_data(features)}.to_json
   end
 end

--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -186,6 +186,9 @@ class Api < App
       end
 
       {
+        buildstart: section.buildstart,
+        buildstart_end: section.opening || section.closure || FeatureCollection::Section::FUTURE,
+        section_closure: section.closure || FeatureCollection::Section::FUTURE,
         length: section.length,
         lines: lines
       }

--- a/api/app/helpers/editor_helpers.rb
+++ b/api/app/helpers/editor_helpers.rb
@@ -44,7 +44,7 @@ module EditorHelpers
 
       groups.each_pair do |line_group, group|
         max_line_group = line_group
-        if new_range = overlap?(group[:range], from..to)
+        if new_range = overlapping_range(group[:range], from..to)
           group[:range] = new_range
           group[:feature_lines] << feature_line
           added = true
@@ -130,8 +130,8 @@ module EditorHelpers
 
   private
 
-  def overlap?(range1, range2)
+  def overlapping_range(range1, range2)
     range1.first < range2.last && range2.first < range1.last ?
-      [range1.min, range2.min].min .. [range1.max, range2.max].max : false
+      [range1.min, range2.min].min .. [range1.max, range2.max].max : nil
   end
 end

--- a/api/app/helpers/editor_helpers.rb
+++ b/api/app/helpers/editor_helpers.rb
@@ -10,14 +10,27 @@ module EditorHelpers
       feature.save
     end
 
-    # Remove
-    lines_to_remove.map do |url_name|
-      Line[url_name: url_name].remove_from_feature(feature)
+    # Remove
+    Line.where(url_name: lines_to_remove).all.map do |line|
+      line.remove_from_feature(feature)
     end
 
     # Add
-    lines_to_add.map do |url_name|
-      Line[url_name: url_name].add_to_feature(feature)
+    Line.where(url_name: lines_to_add).all.map do |line|
+      line.add_to_feature(feature)
+    end
+
+    # line years
+    modified_lines_hash = Hash[properties[:lines].map {|el| [el[:line_url_name], el]}]
+    relac_klass = feature.is_a?(Station) ? StationLine : SectionLine
+    attr = feature.is_a?(Station) ? :station_id : :section_id
+    relac_klass.where(attr => feature.id).all do |feature_line|
+      modified_line = modified_lines_hash[feature_line.line.url_name]
+      if modified_line[:from] != feature_line.fromyear or modified_line[:to] != feature_line.toyear
+        feature_line.fromyear = modified_line[:from]
+        feature_line.toyear = modified_line[:to]
+        feature_line.save
+      end
     end
   end
 

--- a/api/app/helpers/editor_helpers.rb
+++ b/api/app/helpers/editor_helpers.rb
@@ -19,12 +19,14 @@ module EditorHelpers
     Line.where(url_name: lines_to_add).all.map do |line|
       line.add_to_feature(feature)
     end
+  end
 
-    # line years
+  def update_feature_line_years(feature, properties)
     modified_lines_hash = Hash[properties[:lines].map {|el| [el[:line_url_name], el]}]
-    relac_klass = feature.is_a?(Station) ? StationLine : SectionLine
+    feature_lines_klass = feature.is_a?(Station) ? StationLine : SectionLine
     attr = feature.is_a?(Station) ? :station_id : :section_id
-    relac_klass.where(attr => feature.id).all do |feature_line|
+
+    feature_lines_klass.where(attr => feature.id).all do |feature_line|
       modified_line = modified_lines_hash[feature_line.line.url_name]
       if modified_line[:from] != feature_line.fromyear or modified_line[:to] != feature_line.toyear
         feature_line.fromyear = modified_line[:from]
@@ -36,6 +38,7 @@ module EditorHelpers
 
   def update_feature_properties(feature, properties)
     update_feature_lines(feature, properties)
+    update_feature_line_years(feature, properties)
 
     feature.buildstart = properties[:buildstart]
     feature.opening = properties[:opening]

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -24,4 +24,35 @@ module PopupHelpers
       Integer(color[i * 2, 2], 16)
     end
   end
+
+  def popup_features_data(features)
+    section_ids = features.split(',').map do |f|
+      f_parts = f.split('-')
+      f_parts.last if f_parts.first == 'Section'
+    end.compact
+
+    features_data = Section.where(id: section_ids).all.map do |section|
+      lines = section.section_lines.map do |sl|
+        line = sl.line
+        {
+          name: line.name,
+          url_name: line.url_name,
+          system: line.system.name,
+          transport_mode_name: line.transport_mode.name,
+          color: line.color,
+          label_font_color: line_label_font_color(line.color),
+          from: sl.fromyear,
+          to: sl.toyear
+        }
+      end
+
+      {
+        buildstart: section.buildstart,
+        buildstart_end: section.opening || section.closure || FeatureCollection::Section::FUTURE,
+        section_closure: section.closure || FeatureCollection::Section::FUTURE,
+        length: section.length,
+        lines: lines
+      }
+    end
+  end
 end

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -51,7 +51,8 @@ module PopupHelpers
         buildstart_end: section.opening || section.closure || FeatureCollection::Section::FUTURE,
         section_closure: section.closure || FeatureCollection::Section::FUTURE,
         length: section.length,
-        lines: lines
+        lines: lines,
+        section_id: section.id
       }
     end
   end

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -31,7 +31,7 @@ module PopupHelpers
       f_parts.last if f_parts.first == 'Section'
     end.compact
 
-    features_data = Section.where(id: section_ids).all.map do |section|
+    Section.where(id: section_ids).all.map do |section|
       lines = section.section_lines.map do |sl|
         line = sl.line
         {

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -33,6 +33,8 @@ module PopupHelpers
       ids_by_kind[class_name] << id
     end
 
+    data_by_key = {}
+
     ['Station','Section'].map do |class_name|
       ids = ids_by_kind[class_name]
       klass = Kernel.const_get(class_name)
@@ -58,7 +60,7 @@ module PopupHelpers
         # We override buildstart and buildstart_end with
         # feature data (not line data). And we add feature
         # closure data.
-        {
+        data_by_key[[class_name, feature.id].join('-')] = {
           buildstart: feature.buildstart,
           buildstart_end: buildstart_end,
           feature_closure: feature_closure,
@@ -67,6 +69,8 @@ module PopupHelpers
           lines: lines
         }.reject{|k,v| v.blank?}
       end
-    end.flatten
+    end
+
+    data_by_key
   end
 end

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -32,6 +32,9 @@ module PopupHelpers
     end.compact
 
     Section.where(id: section_ids).all.map do |section|
+      buildstart_end = section.opening || section.closure || FeatureCollection::Section::FUTURE
+      section_closure = section.closure || FeatureCollection::Section::FUTURE
+
       lines = section.section_lines.map do |sl|
         line = sl.line
         {
@@ -41,15 +44,18 @@ module PopupHelpers
           transport_mode_name: line.transport_mode.name,
           color: line.color,
           label_font_color: line_label_font_color(line.color),
-          from: sl.fromyear,
-          to: sl.toyear
+          from: sl.fromyear || buildstart_end,
+          to: sl.toyear || section_closure
         }
       end
 
+      # We override buildstart and buildstart_end with
+      # section data (not line data). And we add section
+      # closure data.
       {
         buildstart: section.buildstart,
-        buildstart_end: section.opening || section.closure || FeatureCollection::Section::FUTURE,
-        section_closure: section.closure || FeatureCollection::Section::FUTURE,
+        buildstart_end: buildstart_end,
+        section_closure: section_closure,
         length: section.length,
         lines: lines,
         section_id: section.id

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -33,9 +33,10 @@ module PopupHelpers
       ids_by_kind[class_name] << id
     end
 
-    ids_by_kind.each_pair.map do |class_name, ids|
+    ['Station','Section'].map do |class_name|
+      ids = ids_by_kind[class_name]
       klass = Kernel.const_get(class_name)
-      klass.where(id: ids).all.map do |feature|
+      klass.where(id: ids).order(:id).all.map do |feature|
         buildstart_end = feature.opening || feature.closure || FeatureCollection::Section::FUTURE
         feature_closure = feature.closure || FeatureCollection::Section::FUTURE
         lines_join_table_method = "#{class_name.downcase}_lines"

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -55,7 +55,7 @@ module PopupHelpers
         end
 
         # We override buildstart and buildstart_end with
-        # section data (not line data). And we add section
+        # feature data (not line data). And we add feature
         # closure data.
         {
           buildstart: feature.buildstart,

--- a/api/app/models/station_line.rb
+++ b/api/app/models/station_line.rb
@@ -1,3 +1,5 @@
 class StationLine < Sequel::Model
   plugin :timestamps, :update_on_create => true
+
+  many_to_one :line
 end

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -74,8 +74,8 @@ en:
       station_details: Station details
       other_lines_track: Other lines on the same track
       other_lines_station: Other lines in the same station
-      buildstart: 'Beginning of construction: %(year)s'
-      opening: 'Opening: %(year)s'
+      construction: 'Construction: %(from)s - %(to)s'
+      operation: 'Operation: %(from)s - %(to)s'
       closure: 'Closure: %(year)s'
       length: 'Approximate length: %(km)s km'
   editor:

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
       construction: 'Construction: %(from)s - %(to)s'
       operation: 'Operation: %(from)s - %(to)s'
       closure: 'Closure: %(year)s'
-      length: 'Approximate length: %(km)s km'
+      length: 'Length: %(km)s km'
   editor:
     title: "Edit %(city)s"
     edit_features: Edit features

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -67,9 +67,13 @@ en:
     km_under_construction: 'Under construction: %(km)s km'
     all_lines: All the lines
     popup:
-      station: "%(name)s station"
+      named_station: "%(name)s station"
       unnamed_station: Station
-      track: Track details
+      today: Today
+      track_details: Track details
+      station_details: Station details
+      other_lines_track: Other lines on the same track
+      other_lines_station: Other lines in the same station
       buildstart: 'Beginning of construction: %(year)s'
       opening: 'Opening: %(year)s'
       closure: 'Closure: %(year)s'

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -86,6 +86,10 @@ en:
       selected_feature: Selected feature
       no_feature_selected: No feature selected
       add_line: Add line
+      years:
+        from: From year
+        to: To year
+        note: These settings are optional. The construction and operation info will fall back on the feature data.
       fields:
         klasses_id:
           section: Track Id:%(id)s

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
     popup:
       station: "%(name)s station"
       unnamed_station: Station
-      track: Track information
+      track: Track details
       buildstart: 'Beginning of construction: %(year)s'
       opening: 'Opening: %(year)s'
       closure: 'Closure: %(year)s'

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -71,9 +71,13 @@ es:
     km_under_construction: 'En construcción: %(km)s km'
     all_lines: Todas las líneas
     popup:
-      station: Estación %(name)s
+      named_station: Estación %(name)s
       unnamed_station: Estación
-      track: Detalles del tramo
+      today: Hoy
+      track_details: Detalles del tramo
+      station_details: Detalles de la estación
+      other_lines_track: Otras líneas en el mismo tramo
+      other_lines_station: Otras líneas en la misma estación
       buildstart: 'Comienzo de construcción: %(year)s'
       opening: 'Inauguración: %(year)s'
       closure: 'Cierre: %(year)s'

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -78,8 +78,8 @@ es:
       station_details: Detalles de la estación
       other_lines_track: Otras líneas en el mismo tramo
       other_lines_station: Otras líneas en la misma estación
-      buildstart: 'Comienzo de construcción: %(year)s'
-      opening: 'Inauguración: %(year)s'
+      construction: 'Construcción: %(from)s - %(to)s'
+      operation: 'Operación: %(from)s - %(to)s'
       closure: 'Cierre: %(year)s'
       length: 'Longitud aproximada: %(km)s km'
   editor:

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -93,7 +93,7 @@ es:
       years:
         from: Desde el año
         to: Hasta el año
-        note: Estos parámetros son opcionales. Por defecto se va a usar la informción del elemento.
+        note: Estos parámetros son opcionales. Por defecto se va a usar la información del elemento.
       fields:
         klasses_id:
           section: Tramo Id:%(id)s

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -81,7 +81,7 @@ es:
       construction: 'Construcción: %(from)s - %(to)s'
       operation: 'Operación: %(from)s - %(to)s'
       closure: 'Cierre: %(year)s'
-      length: 'Longitud aproximada: %(km)s km'
+      length: 'Longitud: %(km)s km'
   editor:
     title: "Editar %(city)s"
     edit_features: Editar elementos

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -90,6 +90,10 @@ es:
       selected_feature: Elemento seleccionado
       no_feature_selected: Ningún elemento seleccionado
       add_line: Agregar línea
+      years:
+        from: Desde el año
+        to: Hasta el año
+        note: Estos parámetros son opcionales. Por defecto se va a usar la informción del elemento.
       fields:
         klasses_id:
           section: Tramo Id:%(id)s

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -73,7 +73,7 @@ es:
     popup:
       station: Estación %(name)s
       unnamed_station: Estación
-      track: Información del tramo
+      track: Detalles del tramo
       buildstart: 'Comienzo de construcción: %(year)s'
       opening: 'Inauguración: %(year)s'
       closure: 'Cierre: %(year)s'

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -89,6 +89,10 @@ fr:
       selected_feature: Fonctionnalité sélectionnée
       no_feature_selected: Aucune fonctionnalité sélectionnée
       add_line: Ajouter une ligne
+      years:
+        from: De l'année
+        to: À l'année
+        note: Ces paramètres sont facultatifs. Les informations de construction et d'exploitation seront basées sur les données des éléments. 
       fields:
         klasses_id:
           section: Voie Id:%(id)s

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -79,8 +79,8 @@ fr:
       other_lines_station: Autres lignes sur la même station
       construction: 'Construction: %(from)s - %(to)s'
       operation: 'Opération: %(from)s - %(to)s'
-      closure: 'Fermeture : %(year)s'
-      length: 'Longueur approximative : %(km)s km'
+      closure: 'Fermeture: %(year)s'
+      length: 'Longueur: %(km)s km'
   editor:
     title: "Modifier %(city)s"
     edit_features: Modifier les fonctionnalités

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -77,8 +77,8 @@ fr:
       station_details: Information sur la station
       other_lines_track: Autres lignes sur la même voie
       other_lines_station: Autres lignes sur la même station
-      buildstart: 'Début de la construction : %(year)s'
-      opening: 'Ouverture : %(year)s'
+      construction: 'Construction: %(from)s - %(to)s'
+      operation: 'Opération: %(from)s - %(to)s'
       closure: 'Fermeture : %(year)s'
       length: 'Longueur approximative : %(km)s km'
   editor:

--- a/api/config/locales/fr.yml
+++ b/api/config/locales/fr.yml
@@ -70,9 +70,13 @@ fr:
     km_under_construction: 'En construction : %(km)s km'
     all_lines: Toutes les lignes
     popup:
-      station: Station %(name)s
+      named_station: Station %(name)s
       unnamed_station: Station
-      track: Information sur la voie
+      today: Aujourd'hui
+      track_details: Information sur la voie
+      station_details: Information sur la station
+      other_lines_track: Autres lignes sur la même voie
+      other_lines_station: Autres lignes sur la même station
       buildstart: 'Début de la construction : %(year)s'
       opening: 'Ouverture : %(year)s'
       closure: 'Fermeture : %(year)s'

--- a/api/db/migrations/1598381233_add_line_group_to_station_lines.rb
+++ b/api/db/migrations/1598381233_add_line_group_to_station_lines.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :station_lines do
+      add_column :line_group, Integer, default: 0
+    end
+  end
+end

--- a/api/lib/feature_collection/section.rb
+++ b/api/lib/feature_collection/section.rb
@@ -39,11 +39,13 @@ module FeatureCollection
         select id, length, geometry, osm_id, osm_tags, osm_metadata, opening, buildstart, closure, lines
         from sections
         left join lateral (
-          select section_id, json_agg(json_build_object('line', lines.name,'line_url_name',lines.url_name, 'system', coalesce(systems.name,''))) as lines
-            from section_lines
+          select
+            section_id,
+            json_agg(json_build_object('line', lines.name,'line_url_name',lines.url_name, 'system', coalesce(systems.name,''),'from',fromyear,'to',toyear)) as lines
+          from section_lines
             left join lines on lines.id = section_lines.line_id
             left join systems on systems.id = system_id
-            where section_id = sections.id
+          where section_id = sections.id
           group by section_id
          ) as lines_data on section_id = sections.id
         where ?

--- a/api/lib/feature_collection/section.rb
+++ b/api/lib/feature_collection/section.rb
@@ -62,8 +62,8 @@ module FeatureCollection
                       'id', concat(section_id,'-',line_url_name),
                       'klass', 'Section',
                       'opening', coalesce(line_fromyear,opening, #{FUTURE}),
-                      'buildstart', case when line_fromyear = min_fromyear or min_fromyear is null then coalesce(buildstart,opening) else 0 end,
-                      'buildstart_end',case when line_fromyear = min_fromyear or min_fromyear is null then coalesce(opening, closure, #{FUTURE}) else 0 end,
+                      'buildstart', case when coalesce(line_fromyear,opening) = min_fromyear or min_fromyear is null then coalesce(buildstart,opening) else 0 end,
+                      'buildstart_end',case when coalesce(line_fromyear,opening) = min_fromyear or min_fromyear is null then coalesce(opening, closure, #{FUTURE}) else 0 end,
                       'closure', coalesce(line_toyear,closure, #{FUTURE}),
                       'line_url_name', line_url_name,
                       'width', width,
@@ -94,7 +94,7 @@ module FeatureCollection
           closure,
           section_lines.fromyear as line_fromyear,
           section_lines.toyear as line_toyear,
-          all_lines_data.min_fromyear as min_fromyear,
+          least(min_fromyear, opening) as min_fromyear,
           lines.url_name as line_url_name,
           greatest(lines_data.min_width, (
               case

--- a/api/lib/feature_collection/station.rb
+++ b/api/lib/feature_collection/station.rb
@@ -42,7 +42,7 @@ module FeatureCollection
         left join lateral (
           select
             station_id,
-            json_agg(json_build_object('line',lines.name,'line_url_name',lines.url_name,'system',coalesce(systems.name,''))) as lines
+            json_agg(json_build_object('line',lines.name,'line_url_name',lines.url_name,'system',coalesce(systems.name,''),'from',fromyear,'to',toyear)) as lines
           from station_lines
             left join lines on lines.id = station_lines.line_id
             left join systems on systems.id = system_id

--- a/api/test/unit/helpers/popup_helpers.rb
+++ b/api/test/unit/helpers/popup_helpers.rb
@@ -12,4 +12,162 @@ describe PopupHelpers do
       assert_equal "#000", line_label_font_color("#f3f075")
     end
   end
+
+  describe "#popup_features_data" do
+    before do
+      @city = City.new(name: 'Some city',
+                          start_year: 2017,
+                          url_name: 'city',
+                          country: 'Argentina')
+
+      @city.coords = Sequel.lit("ST_GeomFromText('POINT(-71.064544 42.28787)',4326)")
+      @city.save
+
+      @system = System.create(city_id: @city.id, name: 'A system')
+
+      @line1 = Line.create(city_id: @city.id, system_id: @system.id, name: 'Line 1', url_name: 'line1', color: "#f3f075")
+
+      @section = Section.create(buildstart: 1980, opening: 1985, closure: 1999, city_id: @city.id)
+      @section.geometry = Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)")
+      @section.set_length
+      @section.save
+      @section.reload
+
+      @section_line1 = SectionLine.create(section_id: @section.id, line_id: @line1.id, city_id: @city.id)
+    end
+
+    it "should return data for a feature" do
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          feature_closure: @section.closure,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: @section.opening,
+            to:  @section.closure
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+
+    it "should handle an unset opening" do
+      @section.opening = nil
+      @section.save
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section.closure,
+          feature_closure: @section.closure,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: @section.closure,
+            to:  @section.closure
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+
+    it "should handle an unset closure" do
+      @section.closure = nil
+      @section.save
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          feature_closure: FeatureCollection::Section::FUTURE,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: @section.opening,
+            to: FeatureCollection::Section::FUTURE
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+
+    it "should handle unset opening and closure" do
+      @section.opening = nil
+      @section.closure = nil
+      @section.save
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: FeatureCollection::Section::FUTURE,
+          feature_closure: FeatureCollection::Section::FUTURE,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: FeatureCollection::Section::FUTURE,
+            to: FeatureCollection::Section::FUTURE
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+
+    it "should handle line years data if they are set" do
+      @section_line1.fromyear = 1986
+      @section_line1.toyear = 1998
+      @section_line1.save
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          feature_closure: @section.closure,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: 1986,
+            to: 1998
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+=begin
+    it "should handle multiple features at the same time" do
+
+    end
+=end
+  end
 end

--- a/api/test/unit/helpers/popup_helpers.rb
+++ b/api/test/unit/helpers/popup_helpers.rb
@@ -1,0 +1,15 @@
+require File.expand_path '../../../test_config', __FILE__
+
+describe PopupHelpers do
+  include PopupHelpers
+
+  describe "contrasting colors" do
+    it "should return a contrasting color if the original color is dark" do
+      assert_equal "#fff", line_label_font_color("#c042Be")
+    end
+
+    it "should return a contrasting color if the original color is light" do
+      assert_equal "#000", line_label_font_color("#f3f075")
+    end
+  end
+end

--- a/api/test/unit/helpers/popup_helpers.rb
+++ b/api/test/unit/helpers/popup_helpers.rb
@@ -59,6 +59,41 @@ describe PopupHelpers do
       assert_equal expected_data, popup_features_data("Section-#{@section.id}")
     end
 
+    it "should handle multiple lines" do
+      @line2 = Line.create(city_id: @city.id, system_id: @system.id, name: 'Line 2', url_name: 'line2', color: "#ffff33")
+      @section_line2 = SectionLine.create(section_id: @section.id, line_id: @line2.id, city_id: @city.id)
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          feature_closure: @section.closure,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: @section.opening,
+            to:  @section.closure
+          },{
+            name: @line2.name,
+            url_name: @line2.url_name,
+            system: @line2.system.name,
+            transport_mode_name: @line2.transport_mode.name,
+            color: @line2.color,
+            label_font_color: line_label_font_color(@line2.color),
+            from: @section.opening,
+            to:  @section.closure
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+
     it "should handle an unset opening" do
       @section.opening = nil
       @section.save
@@ -164,10 +199,51 @@ describe PopupHelpers do
 
       assert_equal expected_data, popup_features_data("Section-#{@section.id}")
     end
-=begin
-    it "should handle multiple features at the same time" do
 
+    it "should handle multiple features at the same time" do
+      @station = Station.create(name:'A station', buildstart: 1987, opening: 1988, closure: 1997, city_id: @city.id)
+      @station.geometry = Sequel.lit("ST_GeomFromText('POINT(-71.064544 42.28787)',4326)")
+      @station.save
+
+      @station_line = StationLine.create(station_id: @station.id, line_id: @line1.id, city_id: @city.id)
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          feature_closure: @section.closure,
+          length: @section.length,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: @section.opening,
+            to:  @section.closure
+          }]
+        },
+        "Station-#{@station.id}" => {
+          buildstart: @station.buildstart,
+          buildstart_end: @station.opening,
+          feature_closure: @station.closure,
+          name: @station.name,
+          lines: [{
+            name: @line1.name,
+            url_name: @line1.url_name,
+            system: @line1.system.name,
+            transport_mode_name: @line1.transport_mode.name,
+            color: @line1.color,
+            label_font_color: line_label_font_color(@line1.color),
+            from: @station.opening,
+            to:  @station.closure
+          }]
+        }
+      }
+
+      features = "Section-#{@section.id},Station-#{@station.id}"
+      assert_equal expected_data, popup_features_data(features)
     end
-=end
   end
 end

--- a/api/test/unit/lib/feature_collection/section.rb
+++ b/api/test/unit/lib/feature_collection/section.rb
@@ -241,7 +241,7 @@ describe FeatureCollection::Section do
       assert_equal expected_properties2, features.last[:properties]
     end
 
-    it "should handle two multiple simultaneous lines first, and a single line after" do
+    it "should handle two simultaneous lines first, and a single line after" do
       # Two simulataneous lines until 1995
       # ##################################
       # Original line

--- a/api/test/unit/lib/feature_collection/section.rb
+++ b/api/test/unit/lib/feature_collection/section.rb
@@ -18,7 +18,7 @@ describe FeatureCollection::Section do
     @section.geometry = Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)")
     @section.save
 
-    SectionLine.create(section_id: @section.id, line_id: @line.id, city_id: @city.id)
+    @section_line = SectionLine.create(section_id: @section.id, line_id: @line.id, city_id: @city.id)
 
     @city.reload
   end
@@ -135,6 +135,38 @@ describe FeatureCollection::Section do
       assert_equal expected_properties, feature[:properties]
     end
 
+    it "should contain feature_line years if present" do
+      @section_line.fromyear = 1956
+      @section_line.toyear = 1999
+      @section_line.save
+
+      feature = FeatureCollection::Section.by_feature(@section.id).first
+
+      assert_equal 'Feature', feature[:type]
+      assert feature[:geometry]
+
+      expected_lines = [{
+          line: @line.name,
+          line_url_name: @line.url_name,
+          system: @system.name,
+          from: 1956,
+          to: 1999
+      }]
+
+      expected_properties = {id: @section.id,
+                             klass: "Section",
+                             length: @section.length,
+                             lines: expected_lines,
+                             opening: @section.opening,
+                             buildstart: @section.buildstart,
+                             osm_id: @section.osm_id,
+                             osm_tags: @section.osm_tags,
+                             osm_metadata: @section.osm_metadata,
+                             closure: @section.closure}
+
+      assert_equal expected_properties, feature[:properties]
+    end
+
     it "should set system name to an empty string if it is null" do
       system = System.create(city_id: @city.id)
 
@@ -159,12 +191,8 @@ describe FeatureCollection::Section do
 
       expected_properties = {id: "#{@section.id}-#{@line.url_name}",
                              klass: "Section",
-                             length: @section.length,
-                             line: @line.name,
                              line_url_name: @line.url_name,
-                             transport_mode_name: @line.transport_mode[:name],
                              width: @line.width,
-                             system: @system.name,
                              offset: 0,
                              opening: @section.opening,
                              buildstart: @section.buildstart,
@@ -174,7 +202,7 @@ describe FeatureCollection::Section do
       assert_equal expected_properties, feature[:properties]
     end
 
-    it "should handle multiple lines" do
+    it "should handle multiple simultaneous lines" do
       @line2 = Line.create(city_id: @city.id, system_id: @system.id, name: 'Test line 2', url_name:'test-line-2')
       SectionLine.create(line_id: @line2.id, section_id: @section.id, city_id: @city.id)
 
@@ -190,12 +218,8 @@ describe FeatureCollection::Section do
 
       expected_properties1 = {id: "#{@section.id}-#{@line.url_name}",
                              klass: "Section",
-                             length: @section.length,
-                             line: @line.name,
                              line_url_name: @line.url_name,
-                             transport_mode_name: @line.transport_mode[:name],
                              width: @line.width * 0.75,
-                             system: @system.name,
                              offset: -2.25,
                              opening: @section.opening,
                              buildstart: @section.buildstart,
@@ -206,12 +230,8 @@ describe FeatureCollection::Section do
 
       expected_properties2 = {id: "#{@section.id}-#{@line2.url_name}",
                              klass: "Section",
-                             length: @section.length,
-                             line: @line2.name,
                              line_url_name: @line2.url_name,
-                             transport_mode_name: @line.transport_mode[:name],
                              width: @line2.width * 0.75,
-                             system: @system.name,
                              offset: 2.25,
                              opening: @section.opening,
                              buildstart: @section.buildstart,
@@ -219,6 +239,73 @@ describe FeatureCollection::Section do
                              closure: @section.closure}
 
       assert_equal expected_properties2, features.last[:properties]
+    end
+
+    it "should handle two multiple simultaneous lines first, and a single line after" do
+      # Two simulataneous lines until 1995
+      # ##################################
+      # Original line
+      @section_line.toyear = 1995
+      @section_line.save
+      # default line_group is zero
+
+      # New line before 1995
+      @line2 = Line.create(city_id: @city.id, system_id: @system.id, name: 'Test line 2', url_name:'test-line-2')
+      SectionLine.create(line_id: @line2.id, section_id: @section.id, city_id: @city.id, toyear: 1995)
+      # default line_group is zero
+
+      # One single line after 1995
+      # ##########################
+      # This line has another line_group, in order to show it with another offset
+      # The line_group is set when updating the feature (see EditorHelpers).
+      @line3 = Line.create(city_id: @city.id, system_id: @system.id, name: 'Test line 3', url_name:'test-line-3')
+      SectionLine.create(line_id: @line3.id, section_id: @section.id, city_id: @city.id, fromyear: 1995, line_group: 1)
+
+      features = FeatureCollection::Section.by_feature(@section.id, formatted: true)
+
+      assert 3, features.count
+
+      expected_properties = [
+        {
+          id: "#{@section.id}-#{@line.url_name}",
+          klass: "Section",
+          line_url_name: @line.url_name,
+          width: @line.width * 0.75,
+          offset: -2.25,
+          opening: @section.opening,
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          closure: 1995
+        },
+        {
+          id: "#{@section.id}-#{@line2.url_name}",
+          klass: "Section",
+          line_url_name: @line2.url_name,
+          width: @line2.width * 0.75,
+          offset: 2.25,
+          opening: @section.opening,
+          buildstart: @section.buildstart,
+          buildstart_end: @section.opening,
+          closure: 1995
+        },
+        {
+          id: "#{@section.id}-#{@line3.url_name}",
+          klass: "Section",
+          line_url_name: @line3.url_name,
+          width: @line3.width,
+          offset: 0,
+          opening: 1995,
+          buildstart: 0,
+          buildstart_end: 0,
+          closure: @section.closure
+        }
+      ]
+
+      features.each_with_index do |feature, idx|
+        assert_equal 'Feature', feature[:type]
+        assert feature[:geometry]
+        assert_equal expected_properties[idx], feature[:properties]
+      end
     end
 
     describe "width" do

--- a/api/test/unit/lib/feature_collection/station.rb
+++ b/api/test/unit/lib/feature_collection/station.rb
@@ -18,7 +18,7 @@ describe FeatureCollection::Station do
     @station.geometry = Sequel.lit("ST_GeomFromText('POINT(-71.064544 42.28787)',4326)")
     @station.save
 
-    StationLine.create(station_id: @station.id, line_id: @line.id, city_id: @city.id)
+    @station_line = StationLine.create(station_id: @station.id, line_id: @line.id, city_id: @city.id)
 
     @city.reload
   end
@@ -47,164 +47,145 @@ describe FeatureCollection::Station do
     assert_empty feature_collection[:features]
   end
 
-  it "should return empty lines if no lines data is available" do
-    StationLine.where(line_id: @line.id).destroy
-    @line.destroy
+  describe "raw features" do
+    it "should return empty lines if no lines data is available in the raw feature" do
+      StationLine.where(line_id: @line.id).destroy
+      @line.destroy
 
-    feature = FeatureCollection::Station.by_feature(@station.id).first
-    assert_empty feature[:properties][:lines]
-
-    feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
-    assert_empty feature[:properties][:lines]
-  end
-
-  it "formatted_feature should add width, buildstart_end and transport_mode_name to raw_feature, and remove osm fields" do
-    expected_feature = FeatureCollection::Station.by_feature(@station.id).first
-    expected_feature[:properties].merge!(
-      width: @line.width,
-      inner_width: @line.width - 2,
-      buildstart_end: @station.opening,
-      line_url_name: @station.lines.first.url_name,
-    ).reject!{|f| [:osm_tags, :osm_id, :osm_metadata].include?(f)}
-
-    expected_feature[:properties][:lines].first[:transport_mode_name] = @line.transport_mode[:name]
-
-    formatted_feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
-    assert_equal expected_feature, formatted_feature
-  end
-
-  it "should return the right feature, with osm fields because it is raw" do
-    feature = FeatureCollection::Station.by_feature(@station.id).first
-
-    assert_equal 'Feature', feature[:type]
-    assert feature[:geometry]
-
-    expected_lines = [{
-      line: @line.name,
-      line_url_name: @line.url_name,
-      system: @system.name,
-    }]
-
-    expected_properties = {id: @station.id,
-                           klass: "Station",
-                           lines: expected_lines,
-                           name: @station.name,
-                           opening: @station.opening,
-                           buildstart: @station.buildstart,
-                           osm_id: @station.osm_id,
-                           osm_tags: @station.osm_tags,
-                           osm_metadata: @station.osm_metadata,
-                           closure: @station.closure,
-    }
-
-    assert_equal expected_properties, feature[:properties]
-  end
-
-  it "should use FUTURE values if opening or closure are nil" do
-    @station.opening = nil
-    @station.closure = nil
-    @station.save
-
-    feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
-
-    expected_lines = [{
-      line: @line.name,
-      line_url_name: @line.url_name,
-      system: @system.name,
-      transport_mode_name: @line.transport_mode[:name]
-    }]
-
-    expected_properties = {id: @station.id,
-                           klass: "Station",
-                           lines: expected_lines,
-                           line_url_name: @station.lines.first.url_name,
-                           name: @station.name,
-                           opening: FeatureCollection::Station::FUTURE,
-                           buildstart: @station.buildstart,
-                           buildstart_end: FeatureCollection::Station::FUTURE,
-                           closure: FeatureCollection::Station::FUTURE,
-                           width: @line.width,
-                           inner_width: @line.width - 2,
-    }
-
-    assert_equal expected_properties, feature[:properties]
-  end
-
-  it "should use opening values if buildstart is not set" do
-    @station.buildstart = nil
-    @station.save
-
-    feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
-
-    expected_lines = [{
-      line: @line.name,
-      line_url_name: @line.url_name,
-      system: @system.name,
-      transport_mode_name: @line.transport_mode[:name]
-    }]
-
-    expected_properties = {id: @station.id,
-                           klass: "Station",
-                           lines: expected_lines,
-                           line_url_name: @station.lines.first.url_name,
-                           name: @station.name,
-                           opening: @station.opening,
-                           buildstart: @station.opening,
-                           buildstart_end: @station.opening,
-                           closure: @station.closure,
-                           width: @line.width,
-                           inner_width: @line.width - 2,
-    }
-
-    assert_equal expected_properties, feature[:properties]
-  end
-
-  it "should set system name to an empty string if it is null" do
-    system = System.create(city_id: @city.id)
-
-    @line.system_id = system.id
-    @line.save
-
-    feature = FeatureCollection::Station.by_feature(@station.id).first
-
-    assert_equal '', feature[:properties][:lines].first[:system]
-  end
-
-  it "should return the 'shared station' url_name, and the extra url_nam attrs, if it has more than 1 line" do
-    second_line = Line.create(name:'Other line', city_id: @city.id, url_name:'other-line-url-name', system_id: @system.id)
-
-    StationLine.create(line_id: second_line.id, station_id: @station.id, city_id: @city.id)
-
-    feature_props = FeatureCollection::Station.by_feature(@station.id, formatted: true).first[:properties]
-
-    assert_equal 2, @station.lines.count
-    assert_equal FeatureCollection::Station::SHARED_STATION_LINE_URL_NAME, feature_props[:line_url_name]
-    assert_equal 'a-url-name', feature_props[:line_url_name_1]
-    assert_equal 'other-line-url-name', feature_props[:line_url_name_2]
-  end
-
-  describe "width" do
-    it "should set the radius using the line with the max width" do
-      line2 = Line.create(name: 'Other line', city_id: @city.id, url_name: 'other-line', system_id: @system.id, transport_mode_id: 1)
-      StationLine.create(line_id: line2.id, station_id: @station.id, city_id: @city.id)
-
-      feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
-
-      assert line2.width > @line.width
-      assert_equal 2, @station.lines.count
-      assert_equal line2.width, feature[:properties][:width]
-      assert_equal line2.width - 2, feature[:properties][:inner_width]
+      feature = FeatureCollection::Station.by_feature(@station.id).first
+      assert_empty feature[:properties][:lines]
     end
 
-    it "should set a 0 inner_radius if the radius if lower than 4" do
-      # transport mode 7 is people mover, with a radius of 3
-      @line.transport_mode_id = 7
+    it "should return the right feature, with osm fields because it is raw" do
+      feature = FeatureCollection::Station.by_feature(@station.id).first
+
+      assert_equal 'Feature', feature[:type]
+      assert feature[:geometry]
+
+      expected_lines = [{
+        line: @line.name,
+        line_url_name: @line.url_name,
+        system: @system.name,
+      }]
+
+      expected_properties = {id: @station.id,
+                             klass: "Station",
+                             lines: expected_lines,
+                             name: @station.name,
+                             opening: @station.opening,
+                             buildstart: @station.buildstart,
+                             osm_id: @station.osm_id,
+                             osm_tags: @station.osm_tags,
+                             osm_metadata: @station.osm_metadata,
+                             closure: @station.closure,
+      }
+
+      assert_equal expected_properties, feature[:properties]
+    end
+
+    it "should set system name to an empty string if it is null" do
+      system = System.create(city_id: @city.id)
+
+      @line.system_id = system.id
       @line.save
+
+      feature = FeatureCollection::Station.by_feature(@station.id).first
+
+      assert_equal '', feature[:properties][:lines].first[:system]
+    end
+  end
+
+  describe "formatted features" do
+    it "formatted_feature should add width and buildstart_end to raw_feature, remove osm fields, lines and name, and overwrite the id" do
+      expected_feature = FeatureCollection::Station.by_feature(@station.id).first
+      expected_feature[:properties].merge!(
+        id: "#{@station.id}-#{@station_line.line_group}",
+        width: @line.width,
+        inner_width: @line.width - 2,
+        buildstart_end: @station.opening,
+        line_url_name: @station.lines.first.url_name,
+      ).reject!{|f| [:osm_tags, :osm_id, :osm_metadata, :lines, :name].include?(f)}
+
+      formatted_feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
+      assert_equal expected_feature, formatted_feature
+    end
+
+    it "should use FUTURE values if opening or closure are nil" do
+      @station.opening = nil
+      @station.closure = nil
+      @station.save
+
+      feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
+      expected_properties = {id: "#{@station.id}-#{@station_line.line_group}",
+                             klass: "Station",
+                             line_url_name: @station.lines.first.url_name,
+                             opening: FeatureCollection::Station::FUTURE,
+                             buildstart: @station.buildstart,
+                             buildstart_end: FeatureCollection::Station::FUTURE,
+                             closure: FeatureCollection::Station::FUTURE,
+                             width: @line.width,
+                             inner_width: @line.width - 2,
+      }
+
+      assert_equal expected_properties, feature[:properties]
+    end
+
+    it "should use opening values if buildstart is not set" do
+      @station.buildstart = nil
+      @station.save
 
       feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
 
-      assert_equal 3, feature[:properties][:width]
-      assert_equal 0, feature[:properties][:inner_width]
+      expected_properties = {id: "#{@station.id}-#{@station_line.line_group}",
+                             klass: "Station",
+                             line_url_name: @station.lines.first.url_name,
+                             opening: @station.opening,
+                             buildstart: @station.opening,
+                             buildstart_end: @station.opening,
+                             closure: @station.closure,
+                             width: @line.width,
+                             inner_width: @line.width - 2,
+      }
+
+      assert_equal expected_properties, feature[:properties]
+    end
+
+    it "should return the 'shared station' url_name, and the extra url_nam attrs, if it has more than 1 line" do
+      second_line = Line.create(name:'Other line', city_id: @city.id, url_name:'other-line-url-name', system_id: @system.id)
+
+      StationLine.create(line_id: second_line.id, station_id: @station.id, city_id: @city.id)
+
+      feature_props = FeatureCollection::Station.by_feature(@station.id, formatted: true).first[:properties]
+
+      assert_equal 2, @station.lines.count
+      assert_equal FeatureCollection::Station::SHARED_STATION_LINE_URL_NAME, feature_props[:line_url_name]
+      assert_equal 'a-url-name', feature_props[:line_url_name_1]
+      assert_equal 'other-line-url-name', feature_props[:line_url_name_2]
+    end
+
+    describe "width" do
+      it "should set the radius using the line with the max width" do
+        line2 = Line.create(name: 'Other line', city_id: @city.id, url_name: 'other-line', system_id: @system.id, transport_mode_id: 1)
+        StationLine.create(line_id: line2.id, station_id: @station.id, city_id: @city.id)
+
+        feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
+
+        assert line2.width > @line.width
+        assert_equal 2, @station.lines.count
+        assert_equal line2.width, feature[:properties][:width]
+        assert_equal line2.width - 2, feature[:properties][:inner_width]
+      end
+
+      it "should set a 0 inner_radius if the radius if lower than 4" do
+        # transport mode 7 is people mover, with a radius of 3
+        @line.transport_mode_id = 7
+        @line.save
+
+        feature = FeatureCollection::Station.by_feature(@station.id, formatted: true).first
+
+        assert_equal 3, feature[:properties][:width]
+        assert_equal 0, feature[:properties][:inner_width]
+      end
     end
   end
 end

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -317,14 +317,19 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   padding: 2px 0;
 }
 
-.editor-features-lines-item .fa {
+.editor-features-lines-item .line-commands {
   position: absolute;
   right: 30px;
   margin-top:3px;
   color: #888;
 }
 
-.editor-features-lines-item .fa:hover {
+.editor-features-lines-item .line-commands .far + .far {
+  margin-right: 2px;
+  margin-left: 7px;
+}
+
+.editor-features-lines-item .line-commands .far:hover {
   color: #000;
   cursor: pointer;
 }

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -174,14 +174,6 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   margin-top:4px;
 }
 
-.transport-mode-label {
-  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
-}
-
-.home-status-badge {
-  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
-}
-
 .panel-header-title {
   padding:25px 0 20px 0;
 }
@@ -367,10 +359,6 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
 
 .year-and-km-container {
   padding: 0 15px 20px 15px;
-}
-
-.km-indicator .c-badge {
-  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
 }
 
 .km-indicator .c-badge--success {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -179,11 +179,6 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
 }
 
-.year-build-status {
-  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
-  margin-bottom:3px;
-}
-
 .home-status-badge {
   box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
 }
@@ -358,8 +353,16 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   padding: 0 15px 20px 15px;
 }
 
+.km-indicator .c-badge {
+  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
+}
+
 .km-indicator .c-badge--success {
   margin-right: 5px;
+}
+
+.km-indicator .c-badge + .c-badge {
+  margin-top: 3px;
 }
 
 .edit-mode-buttons {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -726,10 +726,6 @@ table .narrow {
   height:100%;
 }
 
-.avatar-shadow {
-  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
-}
-
 .user-page-username {
   margin-left: 20px;
   display:inline;

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -249,6 +249,10 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   vertical-align: top;
 }
 
+.line-label-li {
+  padding-top: 5px;
+}
+
 .edit-city-link {
   margin-left:10px;
 }

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -175,6 +175,10 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   margin-bottom: 5px;
 }
 
+.transport-mode-label {
+  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
+}
+
 .panel-header-title {
   padding:25px 0 20px 0;
 }

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -317,11 +317,15 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   padding: 2px 0;
 }
 
+.editor-features-lines-item .line-name {
+  max-width: 190px;
+  display: inline-block;
+}
+
 .editor-features-lines-item .line-commands {
-  position: absolute;
-  right: 30px;
-  margin-top:3px;
+  margin-left: 10px;
   color: #888;
+  float: right;
 }
 
 .editor-features-lines-item .line-commands .far + .far {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -179,6 +179,15 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
 }
 
+.year-build-status {
+  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
+  margin-bottom:3px;
+}
+
+.home-status-badge {
+  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
+}
+
 .panel-header-title {
   padding:25px 0 20px 0;
 }
@@ -713,6 +722,10 @@ table .narrow {
   line-height: 200%;
   font-size: 1.5em;
   height:100%;
+}
+
+.avatar-shadow {
+  box-shadow: 0 1.5px 0 rgba(0,0,0,0.1);
 }
 
 .user-page-username {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -145,7 +145,7 @@
 }
 
 .popup-data-title {
-  padding-top: 5px;
+  padding: 5px 0;
   font-weight: lighter;
 }
 
@@ -250,7 +250,7 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
 }
 
 .line-label-li {
-  padding-top: 5px;
+  padding-top: 2px;
 }
 
 .edit-city-link {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -244,6 +244,11 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   vertical-align:top;
 }
 
+.line-label-system {
+  line-height: 18px;
+  vertical-align: top;
+}
+
 .edit-city-link {
   margin-left:10px;
 }

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -134,12 +134,6 @@
   font-size:1.15em;
 }
 
-
-.popup-transport-mode {
-  margin-right: 5px;
-  margin-top:4px;
-}
-
 .popup-data {
   display: none;
 }
@@ -173,6 +167,11 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
 
 .popup-transport-modes {
   margin-bottom: 5px;
+}
+
+.popup-transport-modes .c-badge {
+  margin-right: 5px;
+  margin-top:4px;
 }
 
 .transport-mode-label {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -153,15 +153,10 @@
   width: 100%;
   display: block;
   text-align: right;
-  margin-top: 5px;
 }
 
 .popup-data-checkbox {
   display: none;
-}
-
-.popup-data-toggle > span {
-  font-weight: bold;
 }
 
 .popup-data-toggle > .show-more {
@@ -176,8 +171,8 @@ input.popup-data-checkbox:checked + .popup-data { display: block; }
 input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-more { display: none; }
 input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-less { display: block; }
 
-.panel-header {
-
+.popup-transport-modes {
+  margin-bottom: 5px;
 }
 
 .panel-header-title {
@@ -251,6 +246,7 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
 
 .line-label-li {
   padding-top: 2px;
+  padding-bottom: 5px;
 }
 
 .edit-city-link {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -365,10 +365,6 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   margin-right: 5px;
 }
 
-.km-indicator .c-badge + .c-badge {
-  margin-top: 3px;
-}
-
 .edit-mode-buttons {
   padding: 10px 15px 20px 15px;
 }

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -305,6 +305,10 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   left:3px;
 }
 
+.editor-features-lines-container {
+  width: 100%;
+}
+
 .editor-features-lines-item {
   padding: 2px 0;
 }
@@ -635,7 +639,7 @@ span.osm-container {
 select.osm-route {
   display: inline-block;
   border: none;
-  width: auto;
+  width: 105px;
 }
 
 .osm-container .preamble {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -146,7 +146,7 @@
 
 .popup-data-title {
   padding-top: 5px;
-  font-style: italic;
+  font-weight: lighter;
 }
 
 .popup-data-toggle {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -329,6 +329,7 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   margin-left: 7px;
 }
 
+.editor-features-lines-item .line-commands .selected,
 .editor-features-lines-item .line-commands .far:hover {
   color: #000;
   cursor: pointer;

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -335,6 +335,13 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   cursor: pointer;
 }
 
+.editor-features-lines-item .line-years {
+  padding: 4px;
+  background-color: rgba(0,0,0,0.05);
+  margin: 4px 1px;
+  border-radius: 3px;
+}
+
 .color-picker-container {
   position:absolute;
   z-index:100000;

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -233,9 +233,9 @@ input.popup-data-checkbox:checked + .popup-data + .popup-data-toggle > .show-les
   min-width:21px;
   text-align:center;
   border-radius:2px;
-  min-height:20px;
   line-height:12px;
   vertical-align:top;
+  padding-bottom: 4px;
 }
 
 .line-label-system {

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -89,7 +89,7 @@ class DetailedData extends Component {
       <div>
         <input className="popup-data-checkbox" id={this.props.id} type='checkbox'></input>
         <div className="popup-data">
-          <li className="c-list__item">
+          <li className="c-list__item popup-transport-modes">
             { this.transportModes().map(t =>
                <Translate key={t} className="c-badge c-badge--ghost popup-transport-mode" content={`transport_modes.${t}`} />
             ) }
@@ -145,7 +145,7 @@ class LineLabel extends Component {
         <span className="c-text--highlight line-label" style={this.lineStyle()}>{this.props.line.name}</span>
         <strong className="line-label-system">{this.props.line.system}</strong>
         {this.props.showYears &&
-          <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>}
+          <div className="line-label-system">{`${this.props.line.from} - ${validOrToday(this.props.line.to)}`}</div>}
       </li>
     )
   }

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -143,10 +143,10 @@ class LineLabel extends Component {
       <li className="c-list__item">
         <span className="c-text--highlight line-label" style={this.lineStyle(this.props.line)}>{this.props.line.name}</span>
         {this.props.strong ?
-          <strong>{this.props.line.system}</strong> :
-          <span>{this.props.line.system}</span>}
+          <strong className="line-label-system">{this.props.line.system}</strong> :
+          <span className="line-label-system">{this.props.line.system}</span>}
         {this.props.showYears && this.props.line.from &&
-            <span>{` (${this.props.line.from} - ${this.props.line.to ? this.props.line.to : 'Today'})`}</span>
+            <span className="line-label-system">{` (${this.props.line.from} - ${this.props.line.to ? this.props.line.to : 'Today'})`}</span>
         }
       </li>
     )

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -9,33 +9,11 @@ const validFeatureValue = (value) => value !== null && value !== 0 && value !== 
 
 const validOrToday = (value) => validFeatureValue(value) ? value : counterpart('city.popup.today');
 
-const lineStyle = (line) => ({
-  color: line.label_font_color,
-  backgroundColor: line.color,
-  marginLeft: 0,
-  marginRight: 5,
-  boxShadow: line.label_font_color === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null
-});
-
 /*****************/
 
 class FeaturePopupContent extends Component {
   fProps() {
     return this.props.feature.properties;
-  }
-
-  groupedSystems(lines) {
-    const systems = {};
-
-    lines.map((line) => {
-      if (!systems[line.system]) {
-        systems[line.system] = []
-      };
-
-      systems[line.system].push(line)
-    });
-
-    return systems;
   }
 
   isStation() {
@@ -64,13 +42,11 @@ class FeaturePopupContent extends Component {
                   with={{name: this.fProps().name}}
                 />
               </li>
-              { Object.entries(this.groupedSystems(currentLines)).map(([system, lines]) =>
-                <li key={system} className="c-list__item">
-                  {lines.map((line) =>
-                    <span key={line.name} className="c-text--highlight line-label" style={lineStyle(line)}>{line.name}</span>)}
-                  <strong>{system}</strong>
-                </li>
-              ) }
+              { currentLines.map(line =>
+                <LineLabel
+                  line={line}
+                  key={line.url_name}
+                /> )}
             </div>
               :
             <LineLabel line={currentLines[0]} />
@@ -135,7 +111,7 @@ class DetailedData extends Component {
             </li>}
           { otherLines.length > 0 && otherLines.map(line =>
             <LineLabel
-              line={{...line}}
+              line={line}
               key={line.url_name}
               showYears={true}
             />)}
@@ -150,10 +126,23 @@ class DetailedData extends Component {
 }
 
 class LineLabel extends Component {
+
+  lineStyle() {
+    const line = this.props.line;
+
+    return {
+      color: line.label_font_color,
+      backgroundColor: line.color,
+      marginLeft: 0,
+      marginRight: 5,
+      boxShadow: line.label_font_color === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null
+    }
+  }
+
   render() {
     return (
       <li className="c-list__item line-label-li">
-        <span className="c-text--highlight line-label" style={lineStyle(this.props.line)}>{this.props.line.name}</span>
+        <span className="c-text--highlight line-label" style={this.lineStyle()}>{this.props.line.name}</span>
         <strong className="line-label-system">{this.props.line.system}</strong>
         {this.props.showYears &&
           <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>}

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -115,10 +115,7 @@ class DetailedData extends Component {
             <li className="c-list__item popup-data-title">
               Other lines on the same track
             </li>}
-          { otherLines.length > 0 && otherLines.map(line => <li className="c-list__item popup-data-title">
-              <LineLabel line={line} key={line.url_name} showYears={true} />
-            </li>
-          )}
+          { otherLines.length > 0 && otherLines.map(line => <LineLabel line={line} key={line.url_name} showYears={true} />)}
         </div>
         <label htmlFor={this.props.id} className="popup-data-toggle c-link">
           <span className="show-more"><span className="fas fa-angle-down"/></span>
@@ -142,7 +139,7 @@ class LineLabel extends Component {
 
   render() {
     return (
-      <li className="c-list__item">
+      <li className="c-list__item line-label-li">
         <span className="c-text--highlight line-label" style={this.lineStyle(this.props.line)}>{this.props.line.name}</span>
         {this.props.strong ?
           <strong className="line-label-system">{this.props.line.system}</strong> :

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -124,9 +124,9 @@ class DetailedData extends Component {
           { this.props.length &&
             <li className="c-list__item"><Translate content="city.popup.length" with={{km: formatNumber(parseFloat(this.props.length)/1000)}} /></li>}
           { validFeatureValue(this.props.buildstart) &&
-            <li className="c-list__item">{`Construction: ${this.props.buildstart} - ${validOrToday(this.props.buildstart_end)}`}</li>}
+              <li className="c-list__item"><Translate content="city.popup.construction" with={{from: this.props.buildstart, to: validOrToday(this.props.buildstart_end)}} /></li>}
           { (validFeatureValue(this.props.opening) || validFeatureValue(this.props.closure)) &&
-              <li className="c-list__item">{`Operation: ${this.props.opening} - ${validOrToday(this.props.closure)}`}</li>}
+              <li className="c-list__item"><Translate content="city.popup.operation" with={{from: this.props.opening, to: validOrToday(this.props.closure)}} /></li>}
           { validFeatureValue(this.props.feature_closure) &&
               <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.feature_closure}} /></li> }
           { otherLines.length > 0 &&

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -90,7 +90,7 @@ class DetailedData extends Component {
   render() {
     const otherLines = this.props.lines.
       filter(line => line.url_name != this.props.line_url_name).
-      sort((a,b) => a.fromyear && b.fromyear && a.fromyear > b.fromyear ? 1 : -1);
+      sort((a,b) => a.from && b.from && a.from > b.from ? 1 : -1);
 
     return (
       <div>
@@ -108,14 +108,19 @@ class DetailedData extends Component {
           { validFeatureValue(this.props.buildstart) &&
             <li className="c-list__item">{`Construction: ${this.props.buildstart} - ${validOrToday(this.props.buildstart_end)}`}</li>}
           { (validFeatureValue(this.props.opening) || validFeatureValue(this.props.closure)) &&
-              <li className="c-list__item">{`Line operation: ${this.props.opening} - ${validOrToday(this.props.closure)}`}</li>}
+              <li className="c-list__item">{`Operation: ${this.props.opening} - ${validOrToday(this.props.closure)}`}</li>}
           { validFeatureValue(this.props.section_closure) &&
               <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.section_closure}} /></li> }
           { otherLines.length > 0 &&
             <li className="c-list__item popup-data-title">
               Other lines on the same track
             </li>}
-          { otherLines.length > 0 && otherLines.map(line => <LineLabel line={line} key={line.url_name} showYears={true} />)}
+          { otherLines.length > 0 && otherLines.map(line =>
+            <LineLabel
+              line={{...line}}
+              key={line.url_name}
+              showYears={true}
+            />)}
         </div>
         <label htmlFor={this.props.id} className="popup-data-toggle c-link">
           <span className="show-more"><span className="fas fa-angle-down"/></span>
@@ -142,7 +147,7 @@ class LineLabel extends Component {
       <li className="c-list__item line-label-li">
         <span className="c-text--highlight line-label" style={this.lineStyle(this.props.line)}>{this.props.line.name}</span>
         <strong className="line-label-system">{this.props.line.system}</strong>
-        {this.props.showYears && this.props.line.from &&
+        {this.props.showYears &&
           <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>
         }
       </li>

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -91,7 +91,7 @@ class DetailedData extends Component {
         <div className="popup-data">
           <li className="c-list__item popup-transport-modes">
             { this.transportModes().map(t =>
-               <Translate key={t} className="c-badge c-badge--ghost popup-transport-mode" content={`transport_modes.${t}`} />
+               <Translate key={t} className="c-badge c-badge--ghost popup-transport-mode transport-mode-label" content={`transport_modes.${t}`} />
             ) }
           </li>
           <li className="c-list__item popup-data-title">
@@ -135,7 +135,7 @@ class LineLabel extends Component {
       backgroundColor: line.color,
       marginLeft: 0,
       marginRight: 5,
-      boxShadow: line.label_font_color === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null
+      boxShadow: '0 1.5px 0 rgba(0,0,0,0.1)'
     }
   }
 

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -52,7 +52,7 @@ class FeaturePopupContent extends Component {
           <DetailedData
             isStation={this.isStation()}
             lines={fProps.lines}
-            transport_mode_name={fProps.transport_mode_name}
+            transport_mode_name={currentLine.transport_mode_name}
             buildstart={fProps.buildstart}
             buildstart_end={fProps.buildstart_end}
             line_url_name={fProps.line_url_name}

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -69,7 +69,6 @@ class FeaturePopupContent extends Component {
   }
 }
 
-
 class DetailedData extends Component {
   transportModes() {
     const allModes= this.props.currentLines.map(l => l.transport_mode_name);

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -1,13 +1,13 @@
 import React, {Component} from 'react';
 import Translate from 'react-translate-component';
+import counterpart from 'counterpart';
 import {formatNumber} from '../../lib/number-tools';
 
 /**** Helpers ****/
 
 const validFeatureValue = (value) => value !== null && value !== 0 && value !== 999999;
 
-// FIXME: Replace 'Today' with i18n.
-const validOrToday = (value) => validFeatureValue(value) ? value : 'Today';
+const validOrToday = (value) => validFeatureValue(value) ? value : counterpart('city.popup.today');
 
 const lineStyle = (line) => ({
   color: line.label_font_color,
@@ -60,7 +60,7 @@ class FeaturePopupContent extends Component {
               <li className="c-list__item">
                 <Translate
                   className="station-popup"
-                  content={`city.popup.${this.fProps().name ? '' : 'unnamed_'}station`}
+                  content={`city.popup.${this.fProps().name ? 'named' : 'unnamed'}_station`}
                   with={{name: this.fProps().name}}
                 />
               </li>
@@ -107,6 +107,8 @@ class DetailedData extends Component {
       filter(line => currentUrlNames.indexOf(line.url_name) == -1).
       sort((a,b) => a.from && b.from && a.from > b.from ? 1 : -1);
 
+    const i18nFeaturekey = this.props.isStation ? 'station' : 'track';
+
     return (
       <div>
         <input className="popup-data-checkbox" id={this.props.id} type='checkbox'></input>
@@ -117,7 +119,7 @@ class DetailedData extends Component {
             ) }
           </li>
           <li className="c-list__item popup-data-title">
-            { !this.props.isStation && <Translate content="city.popup.track" /> }
+            <Translate content={`city.popup.${i18nFeaturekey}_details`} />
           </li>
           { this.props.length &&
             <li className="c-list__item"><Translate content="city.popup.length" with={{km: formatNumber(parseFloat(this.props.length)/1000)}} /></li>}
@@ -129,7 +131,7 @@ class DetailedData extends Component {
               <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.feature_closure}} /></li> }
           { otherLines.length > 0 &&
             <li className="c-list__item popup-data-title">
-              Other lines on the same {this.props.isStation ? 'station' : 'track'}
+              <Translate content={`city.popup.other_lines_${i18nFeaturekey}`} />
             </li>}
           { otherLines.length > 0 && otherLines.map(line =>
             <LineLabel

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -58,7 +58,7 @@ class FeaturePopupContent extends Component {
             line_url_name={fProps.line_url_name}
             opening={fProps.opening}
             closure={fProps.closure}
-            section_closure={fProps.section_closure}
+            feature_closure={fProps.feature_closure}
             length={fProps.length}
             id={`${fProps.klass}-${fProps.id}`}
           />
@@ -109,8 +109,8 @@ class DetailedData extends Component {
             <li className="c-list__item">{`Construction: ${this.props.buildstart} - ${validOrToday(this.props.buildstart_end)}`}</li>}
           { (validFeatureValue(this.props.opening) || validFeatureValue(this.props.closure)) &&
               <li className="c-list__item">{`Operation: ${this.props.opening} - ${validOrToday(this.props.closure)}`}</li>}
-          { validFeatureValue(this.props.section_closure) &&
-              <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.section_closure}} /></li> }
+          { validFeatureValue(this.props.feature_closure) &&
+              <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.feature_closure}} /></li> }
           { otherLines.length > 0 &&
             <li className="c-list__item popup-data-title">
               Other lines on the same track

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -68,6 +68,12 @@ class FeaturePopupContent extends Component {
   }
 }
 
+
+const validFeatureValue = (value) => value !== null && value !== 0 && value !== 999999;
+
+// FIXME: Replace 'Today' with i18n.
+const validOrToday = (value) => validFeatureValue(value) ? value : 'Today';
+
 class DetailedData extends Component {
   transportModes() {
     let allModes = [];
@@ -79,10 +85,6 @@ class DetailedData extends Component {
     }
 
     return [ ...new Set(allModes) ].filter(e => e && e != 'default');
-  }
-
-  validFeatureValue(value) {
-    return (value !== null && value !== 0 && value !== 999999);
   }
 
   render() {
@@ -103,11 +105,11 @@ class DetailedData extends Component {
             { !this.props.isStation && <Translate content="city.popup.track" /> }
           </li>
           { this.props.length && <li className="c-list__item"><Translate content="city.popup.length" with={{km: formatNumber(parseFloat(this.props.length)/1000)}} /></li>}
-          { this.validFeatureValue(this.props.buildstart) &&
-            <li className="c-list__item">{`Construction: ${this.props.buildstart} - ${this.props.buildstart_end}`}</li>}
-          { (this.validFeatureValue(this.props.opening) || this.validFeatureValue(this.props.closure)) &&
-              <li className="c-list__item">{`Line operation: ${this.props.opening} - ${this.validFeatureValue(this.props.closure) ? this.props.closure : 'Today'}`}</li>}
-          { this.validFeatureValue(this.props.section_closure) &&
+          { validFeatureValue(this.props.buildstart) &&
+            <li className="c-list__item">{`Construction: ${this.props.buildstart} - ${validOrToday(this.props.buildstart_end)}`}</li>}
+          { (validFeatureValue(this.props.opening) || validFeatureValue(this.props.closure)) &&
+              <li className="c-list__item">{`Line operation: ${this.props.opening} - ${validOrToday(this.props.closure)}`}</li>}
+          { validFeatureValue(this.props.section_closure) &&
               <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.section_closure}} /></li> }
           { otherLines.length > 0 &&
             <li className="c-list__item popup-data-title">
@@ -146,7 +148,7 @@ class LineLabel extends Component {
           <strong className="line-label-system">{this.props.line.system}</strong> :
           <span className="line-label-system">{this.props.line.system}</span>}
         {this.props.showYears && this.props.line.from &&
-            <span className="line-label-system">{` (${this.props.line.from} - ${this.props.line.to ? this.props.line.to : 'Today'})`}</span>
+          <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>
         }
       </li>
     )

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -91,7 +91,7 @@ class DetailedData extends Component {
         <div className="popup-data">
           <li className="c-list__item popup-transport-modes">
             { this.transportModes().map(t =>
-               <Translate key={t} className="c-badge c-badge--ghost popup-transport-mode transport-mode-label" content={`transport_modes.${t}`} />
+               <Translate key={t} className="c-badge c-badge--ghost transport-mode-label" content={`transport_modes.${t}`} />
             ) }
           </li>
           <li className="c-list__item popup-data-title">

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -124,7 +124,7 @@ class DetailedData extends Component {
               <li className="c-list__item"><Translate content="city.popup.closure" with={{year: this.props.feature_closure}} /></li> }
           { otherLines.length > 0 &&
             <li className="c-list__item popup-data-title">
-              Other lines on the same track
+              Other lines on the same {this.props.isStation ? 'station' : 'track'}
             </li>}
           { otherLines.length > 0 && otherLines.map(line =>
             <LineLabel
@@ -149,8 +149,7 @@ class LineLabel extends Component {
         <span className="c-text--highlight line-label" style={lineStyle(this.props.line)}>{this.props.line.name}</span>
         <strong className="line-label-system">{this.props.line.system}</strong>
         {this.props.showYears &&
-          <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>
-        }
+          <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>}
       </li>
     )
   }

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -58,7 +58,11 @@ class FeaturePopupContent extends Component {
           {this.isStation() ?
             <div>
               <li className="c-list__item">
-                <Translate className="station-popup" content={`city.popup.${this.fProps().name ? '' : 'unnamed_'}station`} with={{name: this.fProps().name}} />
+                <Translate
+                  className="station-popup"
+                  content={`city.popup.${this.fProps().name ? '' : 'unnamed_'}station`}
+                  with={{name: this.fProps().name}}
+                />
               </li>
               { Object.entries(this.groupedSystems(currentLines)).map(([system, lines]) =>
                 <li key={system} className="c-list__item">
@@ -115,7 +119,8 @@ class DetailedData extends Component {
           <li className="c-list__item popup-data-title">
             { !this.props.isStation && <Translate content="city.popup.track" /> }
           </li>
-          { this.props.length && <li className="c-list__item"><Translate content="city.popup.length" with={{km: formatNumber(parseFloat(this.props.length)/1000)}} /></li>}
+          { this.props.length &&
+            <li className="c-list__item"><Translate content="city.popup.length" with={{km: formatNumber(parseFloat(this.props.length)/1000)}} /></li>}
           { validFeatureValue(this.props.buildstart) &&
             <li className="c-list__item">{`Construction: ${this.props.buildstart} - ${validOrToday(this.props.buildstart_end)}`}</li>}
           { (validFeatureValue(this.props.opening) || validFeatureValue(this.props.closure)) &&

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -25,9 +25,15 @@ class FeaturePopupContent extends Component {
     return this.fProps().klass === 'Station';
   }
 
+  currentLines() {
+    const urlNames = Object.keys(this.fProps()).
+      map(k => k.indexOf('url_name') > -1 ? this.fProps()[k] : null).
+      filter(el => !!el);
+    return this.fProps().lines.filter(line => urlNames.indexOf(line.url_name) > -1);
+  }
+
   render() {
-    const fProps = this.fProps();
-    const currentLine = fProps.lines.find(el => el.url_name == fProps.line_url_name);
+    const currentLines = this.currentLines();
 
     return (
         <div className="c-text popup-feature-info">
@@ -35,32 +41,31 @@ class FeaturePopupContent extends Component {
           {this.isStation() ?
             <div>
               <li className="c-list__item">
-                <Translate className="station-popup" content={`city.popup.${fProps.name ? '' : 'unnamed_'}station`} with={{name: fProps.name}} />
+                <Translate className="station-popup" content={`city.popup.${this.fProps().name ? '' : 'unnamed_'}station`} with={{name: this.fProps().name}} />
               </li>
-              {Object.entries(this.groupedSystems(fProps.lines)).map((e, index) => {
+              {/*Object.entries(this.groupedSystems(this.fProps().lines)).map((e, index) => {
                   const s = e[1];
                   return <li key={index} className="c-list__item">
                     {s.lines.map((l, index2) => <span key={`l-${index2}`} className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
                     <strong>{s.name}</strong>
                   </li>
                 }
-              )}
+              )*/}
             </div>
               :
-            <LineLabel line={currentLine} />
+            <LineLabel line={currentLines[0]} />
           }
           <DetailedData
             isStation={this.isStation()}
-            lines={fProps.lines}
-            transport_mode_name={currentLine.transport_mode_name}
-            buildstart={fProps.buildstart}
-            buildstart_end={fProps.buildstart_end}
-            line_url_name={fProps.line_url_name}
-            opening={fProps.opening}
-            closure={fProps.closure}
-            feature_closure={fProps.feature_closure}
-            length={fProps.length}
-            id={`${fProps.klass}-${fProps.id}`}
+            lines={this.fProps().lines}
+            currentLines={currentLines}
+            buildstart={this.fProps().buildstart}
+            buildstart_end={this.fProps().buildstart_end}
+            opening={this.fProps().opening}
+            closure={this.fProps().closure}
+            feature_closure={this.fProps().feature_closure}
+            length={this.fProps().length}
+            id={`${this.fProps().klass}-${this.fProps().id}`}
           />
         </ul>
       </div>
@@ -76,20 +81,15 @@ const validOrToday = (value) => validFeatureValue(value) ? value : 'Today';
 
 class DetailedData extends Component {
   transportModes() {
-    let allModes = [];
-
-    if (this.props.isStation) {
-      allModes= this.props.lines.map(l => l.transport_mode_name);
-    } else {
-      allModes.push(this.props.transport_mode_name);
-    }
-
+    const allModes= this.props.currentLines.map(l => l.transport_mode_name);
     return [ ...new Set(allModes) ].filter(e => e && e != 'default');
   }
 
   render() {
+    const currentUrlNames = this.props.currentLines.map(l => l.url_name);
+
     const otherLines = this.props.lines.
-      filter(line => line.url_name != this.props.line_url_name).
+      filter(line => currentUrlNames.indexOf(line.url_name) == -1).
       sort((a,b) => a.from && b.from && a.from > b.from ? 1 : -1);
 
     return (

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -47,7 +47,7 @@ class FeaturePopupContent extends Component {
               )}
             </div>
               :
-            <LineLabel line={currentLine} strong={true} />
+            <LineLabel line={currentLine} />
           }
           <DetailedData
             isStation={this.isStation()}
@@ -141,9 +141,7 @@ class LineLabel extends Component {
     return (
       <li className="c-list__item line-label-li">
         <span className="c-text--highlight line-label" style={this.lineStyle(this.props.line)}>{this.props.line.name}</span>
-        {this.props.strong ?
-          <strong className="line-label-system">{this.props.line.system}</strong> :
-          <span className="line-label-system">{this.props.line.system}</span>}
+        <strong className="line-label-system">{this.props.line.system}</strong>
         {this.props.showYears && this.props.line.from &&
           <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>
         }

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -91,7 +91,7 @@ class DetailedData extends Component {
         <div className="popup-data">
           <li className="c-list__item popup-transport-modes">
             { this.transportModes().map(t =>
-               <Translate key={t} className="c-badge c-badge--ghost transport-mode-label" content={`transport_modes.${t}`} />
+               <Translate key={t} className="c-badge c-badge--ghost" content={`transport_modes.${t}`} />
             ) }
           </li>
           <li className="c-list__item popup-data-title">
@@ -133,8 +133,7 @@ class LineLabel extends Component {
       color: line.label_font_color,
       backgroundColor: line.color,
       marginLeft: 0,
-      marginRight: 5,
-      boxShadow: '0 1.5px 0 rgba(0,0,0,0.1)'
+      marginRight: 5
     }
   }
 

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -144,7 +144,7 @@ class LineLabel extends Component {
       <li className="c-list__item line-label-li">
         <span className="c-text--highlight line-label" style={this.lineStyle()}>{this.props.line.name}</span>
         <strong className="line-label-system">{this.props.line.system}</strong>
-        {this.props.showYears &&
+        {this.props.showYears && validFeatureValue(this.props.line.from) &&
           <div className="line-label-system">{`${this.props.line.from} - ${validOrToday(this.props.line.to)}`}</div>}
       </li>
     )

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -126,7 +126,6 @@ class DetailedData extends Component {
 }
 
 class LineLabel extends Component {
-
   lineStyle() {
     const line = this.props.line;
 

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -2,20 +2,37 @@ import React, {Component} from 'react';
 import Translate from 'react-translate-component';
 import {formatNumber} from '../../lib/number-tools';
 
+/**** Helpers ****/
+
+const validFeatureValue = (value) => value !== null && value !== 0 && value !== 999999;
+
+// FIXME: Replace 'Today' with i18n.
+const validOrToday = (value) => validFeatureValue(value) ? value : 'Today';
+
+const lineStyle = (line) => ({
+  color: line.label_font_color,
+  backgroundColor: line.color,
+  marginLeft: 0,
+  marginRight: 5,
+  boxShadow: line.label_font_color === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null
+});
+
+/*****************/
+
 class FeaturePopupContent extends Component {
   fProps() {
     return this.props.feature.properties;
   }
 
-  groupedSystems(linesInfo) {
-    let systems = {};
+  groupedSystems(lines) {
+    const systems = {};
 
-    linesInfo.map((l) => {
-      if (!systems[l.system]) {
-        systems[l.system] = {name: l.system, lines: []}
+    lines.map((line) => {
+      if (!systems[line.system]) {
+        systems[line.system] = []
       };
 
-      systems[l.system].lines.push(l)
+      systems[line.system].push(line)
     });
 
     return systems;
@@ -43,14 +60,13 @@ class FeaturePopupContent extends Component {
               <li className="c-list__item">
                 <Translate className="station-popup" content={`city.popup.${this.fProps().name ? '' : 'unnamed_'}station`} with={{name: this.fProps().name}} />
               </li>
-              {/*Object.entries(this.groupedSystems(this.fProps().lines)).map((e, index) => {
-                  const s = e[1];
-                  return <li key={index} className="c-list__item">
-                    {s.lines.map((l, index2) => <span key={`l-${index2}`} className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
-                    <strong>{s.name}</strong>
-                  </li>
-                }
-              )*/}
+              { Object.entries(this.groupedSystems(currentLines)).map(([system, lines]) =>
+                <li key={system} className="c-list__item">
+                  {lines.map((line) =>
+                    <span key={line.name} className="c-text--highlight line-label" style={lineStyle(line)}>{line.name}</span>)}
+                  <strong>{system}</strong>
+                </li>
+              ) }
             </div>
               :
             <LineLabel line={currentLines[0]} />
@@ -73,11 +89,6 @@ class FeaturePopupContent extends Component {
   }
 }
 
-
-const validFeatureValue = (value) => value !== null && value !== 0 && value !== 999999;
-
-// FIXME: Replace 'Today' with i18n.
-const validOrToday = (value) => validFeatureValue(value) ? value : 'Today';
 
 class DetailedData extends Component {
   transportModes() {
@@ -132,20 +143,10 @@ class DetailedData extends Component {
 }
 
 class LineLabel extends Component {
-  lineStyle() {
-    return {
-      color: this.props.line.label_font_color,
-      backgroundColor: this.props.line.color,
-      marginLeft: 0,
-      marginRight: 5,
-      boxShadow: this.props.line.label_font_color === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null
-    };
-  }
-
   render() {
     return (
       <li className="c-list__item line-label-li">
-        <span className="c-text--highlight line-label" style={this.lineStyle(this.props.line)}>{this.props.line.name}</span>
+        <span className="c-text--highlight line-label" style={lineStyle(this.props.line)}>{this.props.line.name}</span>
         <strong className="line-label-system">{this.props.line.system}</strong>
         {this.props.showYears &&
           <span className="line-label-system">{` (${this.props.line.from} - ${validOrToday(this.props.line.to)})`}</span>

--- a/client/src/components/city/km-indicator.js
+++ b/client/src/components/city/km-indicator.js
@@ -7,11 +7,11 @@ class KmIndicator extends PureComponent {
     return (
       <div className="km-indicator">
       {this.props.kmOperative ?
-        <span className="c-badge c-badge--success year-build-status">
+        <span className="c-badge c-badge--success">
           <Translate content="city.km_operative" with={{km: formatNumber(this.props.kmOperative)}} />
         </span> : null}
       {this.props.kmUnderConstruction ?
-        <span className="c-badge c-badge--brand year-build-status">
+        <span className="c-badge c-badge--brand">
           <Translate content="city.km_under_construction" with={{km: formatNumber(this.props.kmUnderConstruction)}} />
         </span> : null}
       </div>

--- a/client/src/components/city/km-indicator.js
+++ b/client/src/components/city/km-indicator.js
@@ -7,11 +7,11 @@ class KmIndicator extends PureComponent {
     return (
       <div className="km-indicator">
       {this.props.kmOperative ?
-        <span className="c-badge c-badge--success">
+        <span className="c-badge c-badge--success year-build-status">
           <Translate content="city.km_operative" with={{km: formatNumber(this.props.kmOperative)}} />
         </span> : null}
       {this.props.kmUnderConstruction ?
-        <span className="c-badge c-badge--brand">
+        <span className="c-badge c-badge--brand year-build-status">
           <Translate content="city.km_under_construction" with={{km: formatNumber(this.props.kmUnderConstruction)}} />
         </span> : null}
       </div>

--- a/client/src/components/city/lines-tree.js
+++ b/client/src/components/city/lines-tree.js
@@ -77,7 +77,7 @@ class LinesTreeItem extends PureComponent {
           </div>
           {this.props.name}
           {this.props.transportMode && this.props.showTransportMode &&
-              <Translate className="c-badge c-badge--ghost transport-mode-label" style={{marginLeft:"10px"}} content={`transport_modes.${this.props.transportMode.name}`} />}
+              <Translate className="c-badge c-badge--ghost" style={{marginLeft:"10px"}} content={`transport_modes.${this.props.transportMode.name}`} />}
         </label>
     )
   }

--- a/client/src/components/city/lines-tree.js
+++ b/client/src/components/city/lines-tree.js
@@ -77,7 +77,7 @@ class LinesTreeItem extends PureComponent {
           </div>
           {this.props.name}
           {this.props.transportMode && this.props.showTransportMode &&
-              <Translate className="c-badge c-badge--ghost" style={{marginLeft:"10px"}} content={`transport_modes.${this.props.transportMode.name}`} />}
+              <Translate className="c-badge c-badge--ghost transport-mode-label" style={{marginLeft:"10px"}} content={`transport_modes.${this.props.transportMode.name}`} />}
         </label>
     )
   }

--- a/client/src/components/editor/feature-viewer.js
+++ b/client/src/components/editor/feature-viewer.js
@@ -71,6 +71,15 @@ class FeatureViewer extends PureComponent {
     if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature);
   }
 
+  onLineChange(urlName, attr, value) {
+    const modifiedFeature = {...this.props.feature};
+
+    const line = modifiedFeature.properties.lines.find(l => l.line_url_name == urlName);
+    line[attr] = value;
+
+    if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature);
+  }
+
   render() {
     const properties = this.props.feature ? this.props.feature.properties : null;
 
@@ -86,6 +95,7 @@ class FeatureViewer extends PureComponent {
                     systems={this.props.systems}
                     onAddLine={this.onAddLine.bind(this)}
                     onRemoveLine={this.onRemoveLine.bind(this)}
+                    onLineChange={this.onLineChange.bind(this)}
                   />
                 </td>
               </tr>

--- a/client/src/components/editor/feature-viewer.js
+++ b/client/src/components/editor/feature-viewer.js
@@ -71,7 +71,7 @@ class FeatureViewer extends PureComponent {
     if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature);
   }
 
-  onLineChange(urlName, attr, value) {
+  onLineYearChange(urlName, attr, value) {
     const modifiedFeature = {...this.props.feature};
 
     const line = modifiedFeature.properties.lines.find(l => l.line_url_name == urlName);
@@ -95,7 +95,7 @@ class FeatureViewer extends PureComponent {
                     systems={this.props.systems}
                     onAddLine={this.onAddLine.bind(this)}
                     onRemoveLine={this.onRemoveLine.bind(this)}
-                    onLineChange={this.onLineChange.bind(this)}
+                    onLineYearChange={this.onLineYearChange.bind(this)}
                   />
                 </td>
               </tr>

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -73,7 +73,7 @@ class FeatureLine extends PureComponent {
           <span className="far fa-trash-alt" onClick={() => this.props.onRemove(this.props.urlName)}></span>
         </span>
         {this.state.displayYears &&
-          <div style={{margin:'4px'}}>
+          <div className="line-years">
             <div className="c-input-group">
               <div className="o-field">
                 <input className="c-field u-xsmall" placeholder="From year"/>

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -32,7 +32,7 @@ class FeatureLinesEditor extends PureComponent {
 
   render() {
     return (
-      <ul className="c-list c-list--unstyled">
+      <ul className="c-list c-list--unstyled editor-features-lines-container">
         {this.props.featureLines.sort((a, b) => a.line.localeCompare(b.line)).map((l) =>
           <FeatureLine
             key={l.line_url_name}

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -71,7 +71,7 @@ class FeatureLine extends PureComponent {
   render() {
     return (
       <li key={`own-${this.props.urlName}`}className="c-list__item editor-features-lines-item">
-        {this.props.system ? `${this.props.name} - ${this.props.system}` : l.line}
+        <span className="line-name">{this.props.system ? `${this.props.name} - ${this.props.system}` : l.line}</span>
         <span className="line-commands">
           <span className={`far fa-calendar ${this.state.displayYears ? 'selected' : ''}`} onClick={() => this.toggleYears(this.props.urlName)}></span>
           <span className="far fa-trash-alt" onClick={() => this.props.onRemove(this.props.urlName)}></span>

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -76,13 +76,13 @@ class FeatureLine extends PureComponent {
           <div className="line-years">
             <div className="c-input-group">
               <div className="o-field">
-                <input className="c-field u-xsmall" placeholder="From year"/>
+                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.from' }}/>
               </div>
               <div className="o-field">
-                <input className="c-field u-xsmall" placeholder="To year" />
+                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.to' }}/>
               </div>
             </div>
-            <small>These setting are optional. The construction and operation info will fall back on the feature data.</small>
+            <Translate component="small" content="editor.feature_viewer.years.note" />
           </div>}
       </li>
     )

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -35,9 +35,12 @@ class FeatureLinesEditor extends PureComponent {
       <ul className="c-list c-list--unstyled">
         {this.props.featureLines.sort((a, b) => a.line.localeCompare(b.line)).map((l) =>
           <FeatureLine
+            key={l.line_url_name}
             name={l.line}
             system={l.system}
             urlName={l.line_url_name}
+            from={l.from}
+            to={l.to}
             onRemove={this.props.onRemoveLine.bind(this)}
           />
           )}
@@ -76,10 +79,10 @@ class FeatureLine extends PureComponent {
           <div className="line-years">
             <div className="c-input-group">
               <div className="o-field">
-                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.from' }}/>
+                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.from' }} value={this.props.from}/>
               </div>
               <div className="o-field">
-                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.to' }}/>
+                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.to' }} value={this.props.to} />
               </div>
             </div>
             <Translate component="small" content="editor.feature_viewer.years.note" />

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -42,6 +42,7 @@ class FeatureLinesEditor extends PureComponent {
             from={l.from}
             to={l.to}
             onRemove={this.props.onRemoveLine.bind(this)}
+            onChange={this.props.onLineChange.bind(this)}
           />
           )}
         <li className="c-list__item editor-features-lines-item">
@@ -79,10 +80,22 @@ class FeatureLine extends PureComponent {
           <div className="line-years">
             <div className="c-input-group">
               <div className="o-field">
-                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.from' }} value={this.props.from}/>
+                <Translate
+                  component="input"
+                  className="c-field u-xsmall"
+                  attributes={{ placeholder: 'editor.feature_viewer.years.from' }}
+                  value={this.props.from}
+                  onChange={(e) => this.props.onChange(this.props.urlName, 'from', e.target.value)}
+                />
               </div>
               <div className="o-field">
-                <Translate component="input" className="c-field u-xsmall" attributes={{ placeholder: 'editor.feature_viewer.years.to' }} value={this.props.to} />
+                <Translate
+                  component="input"
+                  className="c-field u-xsmall"
+                  attributes={{ placeholder: 'editor.feature_viewer.years.to' }}
+                  value={this.props.to}
+                  onChange={(e) => this.props.onChange(this.props.urlName, 'to', e.target.value)}
+                />
               </div>
             </div>
             <Translate component="small" content="editor.feature_viewer.years.note" />

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -38,7 +38,13 @@ class FeatureLinesEditor extends PureComponent {
     return (
       <ul className="c-list c-list--unstyled">
         {this.props.featureLines.sort((a, b) => a.line.localeCompare(b.line)).map((l) =>
-          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{l.system ? `${l.line} - ${l.system}` : l.line}<span className="fa fa-trash-alt" onClick={() => this.onRemove(l.line_url_name)}></span></li>
+          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">
+            {l.system ? `${l.line} - ${l.system}` : l.line}
+            <span className="line-commands">
+              <span className="far fa-calendar"></span>
+              <span className="far fa-trash-alt" onClick={() => this.onRemove(l.line_url_name)}></span>
+            </span>
+          </li>
           )}
         <li className="c-list__item editor-features-lines-item">
           <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -42,7 +42,7 @@ class FeatureLinesEditor extends PureComponent {
             from={l.from}
             to={l.to}
             onRemove={this.props.onRemoveLine.bind(this)}
-            onChange={this.props.onLineChange.bind(this)}
+            onYearChange={this.props.onLineYearChange.bind(this)}
           />
           )}
         <li className="c-list__item editor-features-lines-item">
@@ -84,8 +84,9 @@ class FeatureLine extends PureComponent {
                   component="input"
                   className="c-field u-xsmall"
                   attributes={{ placeholder: 'editor.feature_viewer.years.from' }}
-                  value={this.props.from}
-                  onChange={(e) => this.props.onChange(this.props.urlName, 'from', e.target.value)}
+                  type="number"
+                  value={this.props.from || ''}
+                  onChange={(e) => this.props.onYearChange(this.props.urlName, 'from', parseInt(e.target.value))}
                 />
               </div>
               <div className="o-field">
@@ -93,8 +94,9 @@ class FeatureLine extends PureComponent {
                   component="input"
                   className="c-field u-xsmall"
                   attributes={{ placeholder: 'editor.feature_viewer.years.to' }}
-                  value={this.props.to}
-                  onChange={(e) => this.props.onChange(this.props.urlName, 'to', e.target.value)}
+                  type="number"
+                  value={this.props.to || ''}
+                  onChange={(e) => this.props.onYearChange(this.props.urlName, 'to', parseInt(e.target.value))}
                 />
               </div>
             </div>

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -14,10 +14,6 @@ class FeatureLinesEditor extends PureComponent {
     this.props.onAddLine(newLine);
   }
 
-  onRemove(urlName) {
-    this.props.onRemoveLine(urlName);
-  }
-
   remainingLines() {
     const lines = [];
 
@@ -38,13 +34,12 @@ class FeatureLinesEditor extends PureComponent {
     return (
       <ul className="c-list c-list--unstyled">
         {this.props.featureLines.sort((a, b) => a.line.localeCompare(b.line)).map((l) =>
-          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">
-            {l.system ? `${l.line} - ${l.system}` : l.line}
-            <span className="line-commands">
-              <span className="far fa-calendar"></span>
-              <span className="far fa-trash-alt" onClick={() => this.onRemove(l.line_url_name)}></span>
-            </span>
-          </li>
+          <FeatureLine
+            name={l.line}
+            system={l.system}
+            urlName={l.line_url_name}
+            onRemove={this.props.onRemoveLine.bind(this)}
+          />
           )}
         <li className="c-list__item editor-features-lines-item">
           <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>
@@ -55,6 +50,41 @@ class FeatureLinesEditor extends PureComponent {
           </select>
         </li>
       </ul>
+    )
+  }
+}
+
+class FeatureLine extends PureComponent {
+  constructor(props, context) {
+    super(props, context);
+    this.state = {displayYears: false};
+  }
+
+  toggleYears() {
+    this.setState({displayYears: !this.state.displayYears});
+  }
+
+  render() {
+    return (
+      <li key={`own-${this.props.urlName}`}className="c-list__item editor-features-lines-item">
+        {this.props.system ? `${this.props.name} - ${this.props.system}` : l.line}
+        <span className="line-commands">
+          <span className={`far fa-calendar ${this.state.displayYears ? 'selected' : ''}`} onClick={() => this.toggleYears(this.props.urlName)}></span>
+          <span className="far fa-trash-alt" onClick={() => this.props.onRemove(this.props.urlName)}></span>
+        </span>
+        {this.state.displayYears &&
+          <div style={{margin:'4px'}}>
+            <div className="c-input-group">
+              <div className="o-field">
+                <input className="c-field u-xsmall" placeholder="From year"/>
+              </div>
+              <div className="o-field">
+                <input className="c-field u-xsmall" placeholder="To year" />
+              </div>
+            </div>
+            <small>These setting are optional. The construction and operation info will fall back on the feature data.</small>
+          </div>}
+      </li>
     )
   }
 }

--- a/client/src/components/home.js
+++ b/client/src/components/home.js
@@ -62,13 +62,11 @@ class ResultItem extends Component {
           </h3>
         </header>
         <div className="c-card__body">
-          { this.props.length ?
-            <span className="c-badge c-badge--success home-status-badge">{`${formatNumber(this.props.length)} km`}</span>
-            : ''}
+          { this.props.length ? <span className="c-badge c-badge--success">{`${formatNumber(this.props.length)} km`}</span> : ''}
           { this.props.contributors_count ?
             <Translate
               component="span"
-              className="c-badge home-status-badge"
+              className="c-badge"
               style={{marginLeft: 5}}
               content={`cities.contributors.${this.props.contributors_count == 1 ? 'one' : 'other'}`}
               with={{contributors: this.props.contributors_count}} />

--- a/client/src/components/home.js
+++ b/client/src/components/home.js
@@ -62,11 +62,13 @@ class ResultItem extends Component {
           </h3>
         </header>
         <div className="c-card__body">
-          { this.props.length ? <span className="c-badge c-badge--success">{`${formatNumber(this.props.length)} km`}</span> : ''}
+          { this.props.length ?
+            <span className="c-badge c-badge--success home-status-badge">{`${formatNumber(this.props.length)} km`}</span>
+            : ''}
           { this.props.contributors_count ?
             <Translate
               component="span"
-              className="c-badge"
+              className="c-badge home-status-badge"
               style={{marginLeft: 5}}
               content={`cities.contributors.${this.props.contributors_count == 1 ? 'one' : 'other'}`}
               with={{contributors: this.props.contributors_count}} />

--- a/client/src/components/user/avatar.js
+++ b/client/src/components/user/avatar.js
@@ -16,7 +16,7 @@ class Avatar extends PureComponent {
     }
 
     return (
-      <div className={`c-avatar ${extraClasses} avatar-shadow`}>
+      <div className={`c-avatar ${extraClasses}`}>
       { (this.props.img) ?
        <img className="c-avatar__img" alt="placeholder" src={this.props.img}></img>
         :

--- a/client/src/components/user/avatar.js
+++ b/client/src/components/user/avatar.js
@@ -16,7 +16,7 @@ class Avatar extends PureComponent {
     }
 
     return (
-      <div className={`c-avatar ${extraClasses}`}>
+      <div className={`c-avatar ${extraClasses} avatar-shadow`}>
       { (this.props.img) ?
        <img className="c-avatar__img" alt="placeholder" src={this.props.img}></img>
         :

--- a/client/src/stores/city-view-store.js
+++ b/client/src/stores/city-view-store.js
@@ -210,10 +210,13 @@ const CityViewStore = Object.assign({}, Store, {
       return [k, id].join('-');
     });
 
-    const featuresData = await this.fetchFeaturesPopupData(featuresIds);
+    let featuresData = await this.fetchFeaturesPopupData(featuresIds);
+    featuresData = featuresData.sort((a,b) => a.id > b.id ? 1 : -1);
 
-    features.map((el,idx) => {
-      el.properties = { ...el.properties, ...featuresData[idx]};
+    features.
+      sort((a,b) => a.properties.id > b.properties.id ? 1 : -1).
+      map((el,idx) => {
+        el.properties = { ...el.properties, ...featuresData[idx]};
     });
 
     cityData.clickedFeatures = {

--- a/client/src/stores/city-view-store.js
+++ b/client/src/stores/city-view-store.js
@@ -206,21 +206,16 @@ const CityViewStore = Object.assign({}, Store, {
     const featuresIds = features.map(f => {
       const props = f.properties;
       const k = props.klass;
-      const id = k == 'Station' ? props.id : props.id.split('-')[0];
-      props._sort_id = parseInt(id);
-      return [k, id].join('-');
+      const id = props.id.split('-')[0];
+      props._key = [k, id].join('-');
+      return props._key;
     });
 
     const featuresData = await this.fetchFeaturesPopupData(featuresIds);
 
-    // Sorting logic:
-    // - First stations
-    // - First lower _sort_id
     features.
-      sort((a,b) => (a.properties.klass == 'Station' ||
-        (a.properties.klass == b.properties.klass && a.properties._sort_id <= b.properties._sort_id)) ? -1 : 1).
       map((el,idx) => {
-        el.properties = { ...el.properties, ...featuresData[idx]};
+        el.properties = { ...el.properties, ...featuresData[el.properties._key]};
     });
 
     cityData.clickedFeatures = {

--- a/client/src/stores/city-view-store.js
+++ b/client/src/stores/city-view-store.js
@@ -217,7 +217,8 @@ const CityViewStore = Object.assign({}, Store, {
     // - First stations
     // - First lower _sort_id
     features.
-      sort((a,b) => (a.properties.klass == 'Station' || a.properties._sort_id <= b.properties._sort_id ) ? -1 : 1).
+      sort((a,b) => (a.properties.klass == 'Station' ||
+        (a.properties.klass == b.properties.klass && a.properties._sort_id <= b.properties._sort_id)) ? -1 : 1).
       map((el,idx) => {
         el.properties = { ...el.properties, ...featuresData[idx]};
     });

--- a/client/src/stores/city-view-store.js
+++ b/client/src/stores/city-view-store.js
@@ -207,15 +207,17 @@ const CityViewStore = Object.assign({}, Store, {
       const props = f.properties;
       const k = props.klass;
       const id = k == 'Station' ? props.id : props.id.split('-')[0];
-      props.section_id = parseInt(id);
+      props._sort_id = parseInt(id);
       return [k, id].join('-');
     });
 
-    let featuresData = await this.fetchFeaturesPopupData(featuresIds);
-    featuresData = featuresData.sort((a,b) => a.section_id > b.section_id ? 1 : -1);
+    const featuresData = await this.fetchFeaturesPopupData(featuresIds);
 
+    // Sorting logic:
+    // - First stations
+    // - First lower _sort_id
     features.
-      sort((a,b) => a.properties.section_id > b.properties.section_id ? 1 : -1).
+      sort((a,b) => (a.properties.klass == 'Station' || a.properties._sort_id <= b.properties._sort_id ) ? -1 : 1).
       map((el,idx) => {
         el.properties = { ...el.properties, ...featuresData[idx]};
     });

--- a/client/src/stores/city-view-store.js
+++ b/client/src/stores/city-view-store.js
@@ -207,14 +207,15 @@ const CityViewStore = Object.assign({}, Store, {
       const props = f.properties;
       const k = props.klass;
       const id = k == 'Station' ? props.id : props.id.split('-')[0];
+      props.section_id = parseInt(id);
       return [k, id].join('-');
     });
 
     let featuresData = await this.fetchFeaturesPopupData(featuresIds);
-    featuresData = featuresData.sort((a,b) => a.id > b.id ? 1 : -1);
+    featuresData = featuresData.sort((a,b) => a.section_id > b.section_id ? 1 : -1);
 
     features.
-      sort((a,b) => a.properties.id > b.properties.id ? 1 : -1).
+      sort((a,b) => a.properties.section_id > b.properties.section_id ? 1 : -1).
       map((el,idx) => {
         el.properties = { ...el.properties, ...featuresData[idx]};
     });


### PR DESCRIPTION
TODO:
- [x] The buildstart style should correspond only to the first line that will open.
- [x] Popup sections: previous line info should be displayed. This info could be retrieved with a specific request, instead of passing everything in the formatted json.
- [x] Stations
- [x] Fix `features` and `featuresData` sorting (broken with the generalization and the removal of `section_id` prop).
- [x] Popup stations
- [x] Bug: popup crashes when stations and sections with multiple lines are selected at the same time.
- [x] I18n
- [x] Features sorting fails when two different lines of same section (ergo, a duplicated section) is queried.
- [x] Decide whether to remove or note shadows added to the lines and transport modes labels. Removed.
- [x] Restore grouped lines? (This would be equal to the original style)
- ~Station popup: it is not clear to which line the operation dates refer~. It doesn't matter.
- [x] Update Editor UI
- [x] Editor UI: line title collides with new control.
- [x] Years should be read and set from the Editor.
- [x] `line_group` should be set when updating section lines years
- ~Backup for StationLine and SectionLine?~. Not right now.
- ~Option to display only current year lines in the lines legend~. Not right now.
- [x] Tests: `PopupHelpers`
- [x] Tests: `EditorHelpers`
- [x] Tests: `FeatureCollection`

After deploy:
- Clear memcache
- Update dataclips

Closes #141