### PR TITLE
Remove cache from index view and make it lighter

### DIFF
--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -11,6 +11,7 @@ class Api < App
   helpers CityHelpers
   helpers UserHelpers
   helpers CacheHelpers
+  helpers I18nHelpers
 
   use Rack::Cache,
     :verbose     => true,
@@ -22,6 +23,13 @@ class Api < App
 
   before do
     cache_control :no_cache
+  end
+
+  get '/i18n' do
+    cache_control :no_store
+
+    set_locale(params, nil)
+    locale_translations.to_json
   end
 
   namespace '/cities' do

--- a/api/app/controllers/base_app.rb
+++ b/api/app/controllers/base_app.rb
@@ -28,7 +28,6 @@ class BaseApp < App
   # Pre-render title and description for Compare
   get '/compare' do
     @locale = set_locale(params, request)
-    @i18n = locale_translations
 
     @title, @description = compare_title_and_description(params)
     @url = canonical_url(request.url, allowed_params = ['cities', 'locale'])
@@ -39,7 +38,6 @@ class BaseApp < App
   # Pre-render title and description for Data
   get '/data' do
     @locale = set_locale(params, request)
-    @i18n = locale_translations
 
     @title, @description = data_title_and_description
     @url = canonical_url(request.url, allowed_params = ['locale'])
@@ -51,7 +49,6 @@ class BaseApp < App
   # Pre-render title and description for User
   get '/user/:user_id' do |user_id|
     @locale = set_locale(params, request)
-    @i18n = locale_translations
 
     if user = User[user_id]
       @title, @description = user_title_and_description(user)
@@ -65,7 +62,6 @@ class BaseApp < App
   # Pre-render title and description for cities and systems
   get '/:url_name' do |url_name|
     @locale = set_locale(params, request)
-    @i18n = locale_translations
 
     @url = canonical_url(request.url, allowed_params = ['system_id', 'locale'])
 
@@ -82,7 +78,6 @@ class BaseApp < App
 
   get '/*' do
     @locale = set_locale(params, request)
-    @i18n = locale_translations
 
     @title, @description = title_and_description
     @url = canonical_url(request.url, allowed_params = ['locale'])

--- a/api/app/controllers/base_app.rb
+++ b/api/app/controllers/base_app.rb
@@ -17,6 +17,10 @@ class BaseApp < App
   helpers WebpackHelpers
   helpers SEOHelpers
 
+  before do
+    cache_control :public, :must_revalidate, :max_age => 1800
+  end
+
   get '/robots.txt' do
     "Sitemap: #{AWS_HOST}sitemaps/sitemap.xml.gz"
   end

--- a/api/app/controllers/base_app.rb
+++ b/api/app/controllers/base_app.rb
@@ -19,7 +19,6 @@ class BaseApp < App
 
   before do
     cache_control :no_store
-
     @locale = set_locale(params, request)
   end
 

--- a/api/app/controllers/base_app.rb
+++ b/api/app/controllers/base_app.rb
@@ -19,6 +19,8 @@ class BaseApp < App
 
   before do
     cache_control :no_store
+
+    @locale = set_locale(params, request)
   end
 
   get '/robots.txt' do
@@ -27,8 +29,6 @@ class BaseApp < App
 
   # Pre-render title and description for Compare
   get '/compare' do
-    @locale = set_locale(params, request)
-
     @title, @description = compare_title_and_description(params)
     @url = canonical_url(request.url, allowed_params = ['cities', 'locale'])
 
@@ -37,8 +37,6 @@ class BaseApp < App
 
   # Pre-render title and description for Data
   get '/data' do
-    @locale = set_locale(params, request)
-
     @title, @description = data_title_and_description
     @url = canonical_url(request.url, allowed_params = ['locale'])
 
@@ -48,8 +46,6 @@ class BaseApp < App
 
   # Pre-render title and description for User
   get '/user/:user_id' do |user_id|
-    @locale = set_locale(params, request)
-
     if user = User[user_id]
       @title, @description = user_title_and_description(user)
     end
@@ -61,8 +57,6 @@ class BaseApp < App
 
   # Pre-render title and description for cities and systems
   get '/:url_name' do |url_name|
-    @locale = set_locale(params, request)
-
     @url = canonical_url(request.url, allowed_params = ['system_id', 'locale'])
 
     @title, @description = if params[:system_id] and system = System[params[:system_id]]
@@ -77,8 +71,6 @@ class BaseApp < App
   end
 
   get '/*' do
-    @locale = set_locale(params, request)
-
     @title, @description = title_and_description
     @url = canonical_url(request.url, allowed_params = ['locale'])
 

--- a/api/app/controllers/base_app.rb
+++ b/api/app/controllers/base_app.rb
@@ -18,7 +18,7 @@ class BaseApp < App
   helpers SEOHelpers
 
   before do
-    cache_control :public, :must_revalidate, :max_age => 1800
+    cache_control :no_store
   end
 
   get '/robots.txt' do

--- a/api/app/views/index.erb
+++ b/api/app/views/index.erb
@@ -63,7 +63,6 @@
       <script>
         // The assetsPaths is defined so it can be used by the assetsProvider
         window.assetsPaths = <%= (Sprockets::Helpers.manifest ? Sprockets::Helpers.manifest.assets : {}).to_json %>;
-        window.i18n = <%= @i18n.to_json %>;
         window.locale = <%= @locale.to_json %>;
       </script>
       <script src="<%= webpack_asset_path('main.js') %>"></script>

--- a/client/src/components/main.js
+++ b/client/src/components/main.js
@@ -40,6 +40,7 @@ class Main extends Component {
   componentDidMount() {
     MainStore.addChangeListener(this.bindedOnChange);
 
+    MainStore.loadI18n();
     this.checkAuth();
     this.checkCookieAdviceCookie();
   }

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import {render} from 'react-dom';
 import {BrowserRouter as Router, Route} from 'react-router-dom';
-import Counterpart from 'counterpart';
 
 import Main from './components/main';
-
-Counterpart.registerTranslations(window.locale, window.i18n);
-Counterpart.setLocale(window.locale);
 
 import assets from './lib/assets-provider';
 assets.loadPaths(window.assetsPaths);

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import {render} from 'react-dom';
 import {BrowserRouter as Router, Route} from 'react-router-dom';
+import Counterpart from 'counterpart';
 
 import Main from './components/main';
 
 import assets from './lib/assets-provider';
 assets.loadPaths(window.assetsPaths);
+
+Counterpart.setMissingEntryGenerator((key) => '');
 
 render(
     <Router>

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -5,10 +5,10 @@ import Counterpart from 'counterpart';
 
 import Main from './components/main';
 
+Counterpart.setMissingEntryGenerator((key) => '');
+
 import assets from './lib/assets-provider';
 assets.loadPaths(window.assetsPaths);
-
-Counterpart.setMissingEntryGenerator((key) => '');
 
 render(
     <Router>

--- a/client/src/stores/main-store.js
+++ b/client/src/stores/main-store.js
@@ -1,4 +1,5 @@
 import Store from './store';
+import Counterpart from 'counterpart';
 
 const MainStore = Object.assign({}, Store, {
   state: {
@@ -69,6 +70,19 @@ const MainStore = Object.assign({}, Store, {
   unsetLoading() {
     this.state.loading = false;
     this.state = {...this.state};
+
+    this.emitChangeEvent();
+  },
+
+  async loadI18n() {
+    const locale = window.locale;
+    const url = `/api/i18n?locale=${locale}`;
+
+    const response = await fetch(url, {credentials: 'same-origin'});
+    const i18n = await response.json();
+
+    Counterpart.registerTranslations(locale, i18n);
+    Counterpart.setLocale(locale);
 
     this.emitChangeEvent();
   }


### PR DESCRIPTION
This PR:
- Sets a `cache-control: no-store` header for `BaseApp`, which is the app that serves the views. We do this to prevent caching the index page, so we can avoid errors when updating the app.
- Loads the i18n asynchronously, so the index page is lighter.