### PR TITLE
City style fixes

### DIFF
--- a/client/src/components/city.js
+++ b/client/src/components/city.js
@@ -160,7 +160,7 @@ class City extends CityBase {
     if (!this.state) return null;
 
     return (
-        <div className="o-grid o-panel">
+        <>
           <div id="panel" style={this.panelStyle()}>
             <PanelHeader
               name={this.state.name}
@@ -180,7 +180,6 @@ class City extends CityBase {
               </Route>
             </Switch>
           </div>
-          <main className="o-grid__cell o-grid__cell--width-100 o-panel-container">
           <Map
             mapboxAccessToken={this.state.mapbox_access_token}
             mapboxStyle={this.state.mapbox_style}
@@ -229,8 +228,7 @@ class City extends CityBase {
                 </React.Suspense>
               }
           </Map>
-          </main>
-        </div>
+        </>
         );
   }
 }

--- a/client/src/components/main.js
+++ b/client/src/components/main.js
@@ -29,7 +29,7 @@ class Main extends Component {
       if (loc.pathname != this.previousPathname) {
         // This fixes a bug in Safari:
         // the scroll is not set to zero when changing routes
-        document.getElementById('main-container').scrollTop=0;
+        document.getElementById('main-container').scrollTop = 0;
 
         this.previousPathname = loc.pathname;
         ga("send", "pageview", loc.pathname);

--- a/client/src/components/main.js
+++ b/client/src/components/main.js
@@ -27,6 +27,10 @@ class Main extends Component {
     this.previousPathname = null;
     this.props.history.listen( loc =>  {
       if (loc.pathname != this.previousPathname) {
+        // This fixes a bug in Safari:
+        // the scroll is not set to zero when changing routes
+        document.getElementById('main-container').scrollTop=0;
+
         this.previousPathname = loc.pathname;
         ga("send", "pageview", loc.pathname);
       }


### PR DESCRIPTION
- Reset scroll when mounting components in `Main`, to fix Safari bug (scroll is not reset).
- Remove unnecessary div elements from `City`component.