### PR TITLE
Refactor line_groups computation

### DIFF
--- a/api/app/helpers/editor_helpers.rb
+++ b/api/app/helpers/editor_helpers.rb
@@ -160,18 +160,31 @@ module EditorHelpers
       [range1.min, range2.min].min .. [range1.max, range2.max].max : nil
   end
 
+  def compute_groups(ranges)
+    ranges_hash = find_ranges(ranges)
+    groups_hash = {}
+    groups = {}
+    ranges_hash.each_pair do |key, vals|
+      groups_hash[key] ||= vals.map do |val|
+        if !groups[val]
+          groups[val] = groups.keys.length
+        end
+        groups[val]
+      end
+    end
+    groups_hash
+  end
+
   def find_ranges(ranges)
     ranges_hash = {}
     ranges.each_with_index do |r, idx|
-      intersections = []
-      feature_ranges = []
-      ranges.each do |rr|
+      intersections = ranges.map do |rr|
         next if r == rr
         inter_range = intersect_ranges(r, rr)
         if inter_range && inter_range.begin != inter_range.end
-          intersections << inter_range
+          inter_range
         end
-      end
+      end.compact
       min_begin = intersections.map(&:begin).min
       max_end = intersections.map(&:end).max
       if min_begin && min_begin > r.begin

--- a/api/app/helpers/editor_helpers.rb
+++ b/api/app/helpers/editor_helpers.rb
@@ -159,4 +159,43 @@ module EditorHelpers
     range1.first < range2.last && range2.first < range1.last ?
       [range1.min, range2.min].min .. [range1.max, range2.max].max : nil
   end
+
+  def find_ranges(ranges)
+    ranges_hash = {}
+    ranges.each_with_index do |r, idx|
+      intersections = []
+      feature_ranges = []
+      ranges.each do |rr|
+        next if r == rr
+        inter_range = intersect_ranges(r, rr)
+        if inter_range && inter_range.begin != inter_range.end
+          intersections << inter_range
+        end
+      end
+      min_begin = intersections.map(&:begin).min
+      max_end = intersections.map(&:end).max
+      if min_begin && min_begin > r.begin
+        intersections << (r.begin .. min_begin)
+      elsif max_end && max_end < r.end
+        intersections << (max_end .. r.end)
+      end
+      if intersections.blank?
+        intersections << r
+      end
+      ranges_hash[r] = intersections.sort_by{|i| i.begin}
+    end
+    ranges_hash
+  end
+
+  def intersect_ranges(r1, r2)
+    # Taken from:
+    # https://stackoverflow.com/a/15273442/3095803
+    new_end = [r1.end, r2.end].min
+    new_begin = [r1.begin, r2.begin].max
+    exclude_end = (r2.exclude_end? && new_end == r2.end) || (r1.exclude_end? && new_end == r1.end)
+
+    valid = (new_begin <= new_end && !exclude_end)
+    valid ||= (new_begin < new_end && exclude_end)
+    valid ? Range.new(new_begin, new_end, exclude_end) : nil
+  end
 end

--- a/api/test/unit/helpers/editor_helpers.rb
+++ b/api/test/unit/helpers/editor_helpers.rb
@@ -133,28 +133,45 @@ describe EditorHelpers do
 
       it "should test new ranges" do
         ranges = [1930 .. 1940, 1940 .. 1950, 1945 .. 9999]
-        expected_hash = {
+        expected_ranges = {
           1930..1940 => [1930..1940],
           1940..1950 => [1940..1945, 1945..1950],
           1945..9999 => [1945..1950, 1950..9999]
         }
-        assert_equal expected_hash, find_ranges(ranges)
+        expected_groups = {
+          1930..1940 => [0],
+          1940..1950 => [1, 2],
+          1945..9999 => [2, 3]
+        }
+        assert_equal expected_ranges, find_ranges(ranges)
+        assert_equal expected_groups, compute_groups(ranges)
 
         ranges2 = [1930 .. 1940, 1940 .. 1950, 1938 .. 9999]
-        expected_hash2 = {
+        expected_ranges2 = {
           1930..1940 => [1930..1938, 1938..1940],
           1940..1950 => [1940..1950],
           1938..9999 => [1938..1940, 1940..1950, 1950..9999]
         }
-        assert_equal expected_hash2, find_ranges(ranges2)
+        expected_groups2 = {
+          1930..1940 => [0, 1],
+          1940..1950 => [2],
+          1938..9999 => [1, 2, 3]
+        }
+        assert_equal expected_ranges2, find_ranges(ranges2)
+        assert_equal expected_groups2, compute_groups(ranges2)
 
         ranges3 = [1938 .. 9999, 1930 .. 1940, 1940 .. 1950]
-        expected_hash3 = {
+        expected_ranges3 = {
           1938..9999 => [1938..1940, 1940..1950, 1950..9999],
           1930..1940 => [1930..1938, 1938..1940],
           1940..1950 => [1940..1950]
         }
-        assert_equal expected_hash3, find_ranges(ranges3)
+        expected_groups3 = {
+          1938..9999 => [0, 1, 2],
+          1930..1940 => [3, 0],
+          1940..1950 => [1]
+        }
+        assert_equal expected_ranges3, find_ranges(ranges3)
       end
     end
 

--- a/api/test/unit/helpers/editor_helpers.rb
+++ b/api/test/unit/helpers/editor_helpers.rb
@@ -130,6 +130,32 @@ describe EditorHelpers do
            assert_equal section_line[:line_group], section_lines[idx].line_group
          end
       end
+
+      it "should test new ranges" do
+        ranges = [1930 .. 1940, 1940 .. 1950, 1945 .. 9999]
+        expected_hash = {
+          1930..1940 => [1930..1940],
+          1940..1950 => [1940..1945, 1945..1950],
+          1945..9999 => [1945..1950, 1950..9999]
+        }
+        assert_equal expected_hash, find_ranges(ranges)
+
+        ranges2 = [1930 .. 1940, 1940 .. 1950, 1938 .. 9999]
+        expected_hash2 = {
+          1930..1940 => [1930..1938, 1938..1940],
+          1940..1950 => [1940..1950],
+          1938..9999 => [1938..1940, 1940..1950, 1950..9999]
+        }
+        assert_equal expected_hash2, find_ranges(ranges2)
+
+        ranges3 = [1938 .. 9999, 1930 .. 1940, 1940 .. 1950]
+        expected_hash3 = {
+          1938..9999 => [1938..1940, 1940..1950, 1950..9999],
+          1930..1940 => [1930..1938, 1938..1940],
+          1940..1950 => [1940..1950]
+        }
+        assert_equal expected_hash3, find_ranges(ranges3)
+      end
     end
 
     describe "sections geometry validation" do


### PR DESCRIPTION
This PR:
- Improves the way the line groups are computed
- Allows multiple line groups to be assign to one section or station

Hopefully, this will fix #244, #256 and #258 