### PR TITLE
Fix build dates edge cases

### DIFF
--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -81,7 +81,7 @@ module PopupHelpers
         concat('#{klass}','-',id) as id,
         buildstart,
         opening as opening_fallback,
-        coalesce(opening,closure,#{future}) as buildstart_end,
+        coalesce(min_fromyear, opening, closure, #{future}) as buildstart_end,
         coalesce(closure,#{future}) as feature_closure,
         #{klass == 'Section' ? 'length' : 'null::int as length'},
         #{klass == 'Station' ? 'name' : 'null as name'},
@@ -90,7 +90,7 @@ module PopupHelpers
       left join lateral (
         select
           #{aux_table_id},
-          json_agg(json_build_object('name', lines.name,'url_name',lines.url_name, 'system', coalesce(systems.name,''),'historic',systems.historic,'transport_mode_name',transport_modes.name,'color',color,'from',fromyear,'to',toyear)) as lines
+          json_agg(json_build_object('name', lines.name,'url_name',lines.url_name, 'system', coalesce(systems.name,''),'historic',systems.historic,'transport_mode_name',transport_modes.name,'color',color,'from',fromyear,'to',toyear)) as lines, min(fromyear) as min_fromyear
         from #{aux_table_name}
           left join lines on lines.id = #{aux_table_name}.line_id
           left join systems on systems.id = system_id

--- a/api/app/helpers/popup_helpers.rb
+++ b/api/app/helpers/popup_helpers.rb
@@ -81,7 +81,7 @@ module PopupHelpers
         concat('#{klass}','-',id) as id,
         buildstart,
         opening as opening_fallback,
-        coalesce(min_fromyear, opening, closure, #{future}) as buildstart_end,
+        least(min_fromyear, opening, closure, #{future}) as buildstart_end,
         coalesce(closure,#{future}) as feature_closure,
         #{klass == 'Section' ? 'length' : 'null::int as length'},
         #{klass == 'Station' ? 'name' : 'null as name'},

--- a/api/lib/feature_collection/section.rb
+++ b/api/lib/feature_collection/section.rb
@@ -69,7 +69,7 @@ module FeatureCollection
                       'id', concat(section_id,'-',line_url_name,'-', line_group),
                       'klass', 'Section',
                       'opening', actual_opening,
-                      'buildstart', case when actual_opening = min_fromyear or min_fromyear is null then coalesce(buildstart, opening) else actual_opening end,
+                      'buildstart', case when actual_opening = min_fromyear or min_fromyear is null then coalesce(buildstart, actual_opening) else actual_opening end,
                       'buildstart_end', coalesce(actual_opening, closure, #{FUTURE}),
                       'closure', coalesce(line_toyear, closure, #{FUTURE}),
                       'line_url_name', line_url_name,

--- a/api/lib/feature_collection/station.rb
+++ b/api/lib/feature_collection/station.rb
@@ -66,7 +66,7 @@ module FeatureCollection
                         'id', concat(station_id,'-',line_group),
                         'klass', 'Station',
                         'opening', actual_opening,
-                        'buildstart', case when actual_opening = min_fromyear or min_fromyear is null then coalesce(buildstart, opening) else actual_opening end,
+                        'buildstart', case when actual_opening = min_fromyear or min_fromyear is null then coalesce(buildstart, actual_opening) else actual_opening end,
                         'buildstart_end', coalesce(actual_opening, closure, #{FUTURE}),
                         'closure', coalesce(line_toyear, closure, #{FUTURE}),
                         'line_url_name', (case

--- a/api/test/unit/helpers/popup_helpers.rb
+++ b/api/test/unit/helpers/popup_helpers.rb
@@ -200,6 +200,36 @@ describe PopupHelpers do
       assert_equal expected_data, popup_features_data("Section-#{@section.id}")
     end
 
+    it "should use the line's fromyear attr if the global opening date is not set" do
+      @section_line1.fromyear = 1986
+      @section_line1.toyear = 1998
+      @section_line1.save
+
+      @section.opening = nil
+      @section.save
+
+      expected_data = {
+        "Section-#{@section.id}" => {
+          buildstart: @section.buildstart,
+          buildstart_end: @section_line1.fromyear,
+          feature_closure: @section.closure,
+          length: @section.length,
+          lines: [{
+            'name' => @line1.name,
+            'url_name' => @line1.url_name,
+            'system' => @line1.system.name,
+            'transport_mode_name' => @line1.transport_mode.name,
+            'color' => @line1.color,
+            'label_font_color' => line_label_font_color(@line1.color),
+            'from' => 1986,
+            'to' => 1998
+          }]
+        }
+      }
+
+      assert_equal expected_data, popup_features_data("Section-#{@section.id}")
+    end
+
     it "should return handle historical system" do
       @system.historic = true
       @system.save

--- a/api/test/unit/lib/feature_collection/section.rb
+++ b/api/test/unit/lib/feature_collection/section.rb
@@ -375,6 +375,33 @@ describe FeatureCollection::Section do
         assert_equal expected_properties[idx], feature[:properties]
       end
     end
+
+    it "should use the line data if there are no global values" do
+      @section.buildstart = nil
+      @section.opening = nil
+      @section.closure = nil
+      @section.save
+
+      @section_line.fromyear = 1956
+      @section_line.toyear = 1999
+      @section_line.save
+
+      set_feature_line_groups(@section)
+      feature = get_section_formatted_features(@section).first
+
+      expected_properties = {id: "#{@section.id}-#{@line.url_name}-0",
+                             klass: "Section",
+                             line_url_name: @line.url_name,
+                             width: @line.width,
+                             offset: 0,
+                             opening: @section_line.fromyear,
+                             buildstart: @section_line.fromyear,
+                             buildstart_end: @section_line.fromyear,
+                             closure: @section_line.toyear}
+
+      assert_equal expected_properties, feature[:properties]
+    end
+
     describe "width" do
 	    it "should return the right width when the section has 1 line" do
         features = FeatureCollection::Section.by_feature(@section.id, formatted: true)

--- a/api/test/unit/lib/feature_collection/station.rb
+++ b/api/test/unit/lib/feature_collection/station.rb
@@ -186,6 +186,33 @@ describe FeatureCollection::Station do
       assert_equal expected_properties, feature[:properties]
     end
 
+    it "should use the line data if there are no global values" do
+      @station.buildstart = nil
+      @station.opening = nil
+      @station.closure = nil
+      @station.save
+
+      @station_line.fromyear = 1940
+      @station_line.toyear = 1960
+      @station_line.save
+
+      set_feature_line_groups(@station)
+      feature = get_station_formatted_features(@station).first
+
+      expected_properties = {id: "#{@station.id}-0",
+                             klass: "Station",
+                             line_url_name: @station.lines.first.url_name,
+                             opening: @station_line.fromyear,
+                             buildstart: @station_line.fromyear,
+                             buildstart_end: @station_line.fromyear,
+                             closure: @station_line.toyear,
+                             width: @line.width,
+                             inner_width: @line.width - 2,
+      }
+
+      assert_equal expected_properties, feature[:properties]
+    end
+
     it "should return the 'shared station' url_name, and the extra url_nam attrs, if it has more than 1 line" do
       second_line = Line.create(name:'Other line', city_id: @city.id, url_name:'other-line-url-name', system_id: @system.id)
 


### PR DESCRIPTION
This PR addresses these issues:
- [x] Fix: If  build start and opening dates are not set, but there is specific line info, the ´inner´white circle inside the stop is not shown in the first line group
- [x] Fix: Popup: if no explicit global opening date is set, we get invalid construction end dates:
![Captura de Pantalla 2021-10-03 a la(s) 11 13 57](https://user-images.githubusercontent.com/6061036/135757631-8dcca2e1-ee77-4fe8-9a97-b18a3d37554e.png)
- [x] Update tests
