### PR TITLE
Update circleci ubuntu img

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:


### PR DESCRIPTION
As per title, because of EOL of previous ubuntu img.