### PR TITLE
Fix parsing error of locale header

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     google-id-token (1.3.1)
       jwt
       multi_json
-    http-accept (1.7.0)
+    http-accept (2.2.0)
     httpi (2.4.4)
       rack
       socksify

--- a/tools/run
+++ b/tools/run
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-docker-compose up
+docker-compose up $@


### PR DESCRIPTION
Sometimes we get a `HTTP::Accept::ParseError - Could not parse entire string!`.
This PR updates the `http-accept`gem to a version that fixes that.