### PR TITLE
Handle parsing errors of the HTTP_ACCEPT_LANGUAGE header

### DIFF
--- a/api/app/helpers/i18n_helpers.rb
+++ b/api/app/helpers/i18n_helpers.rb
@@ -3,7 +3,12 @@ require "http/accept"
 module I18nHelpers
   def browser_locale(request)
     return if request.env["HTTP_ACCEPT_LANGUAGE"].blank?
-    languages = HTTP::Accept::Languages.parse(request.env["HTTP_ACCEPT_LANGUAGE"])
+    begin
+      languages = HTTP::Accept::Languages.parse(request.env["HTTP_ACCEPT_LANGUAGE"])
+    rescue HTTP::Accept::ParseError
+      logger.warn("Invalid HTTP_ACCEPT_LANGUAGE header: #{request.env["HTTP_ACCEPT_LANGUAGE"]}")
+      return
+    end
     locales = languages.map{|lang| lang.locale.split("-").first.to_sym}.uniq
     (locales & I18n.available_locales).first
   end

--- a/api/test/unit/helpers/i18n_helpers.rb
+++ b/api/test/unit/helpers/i18n_helpers.rb
@@ -26,8 +26,13 @@ describe I18nHelpers do
       refute browser_locale(request)
     end
 
-    it "should reutn nil because the header is nil" do
+    it "should return nil because the header is nil" do
       request = OpenStruct.new(env: {})
+      refute browser_locale(request)
+    end
+
+    it "should return nil because the header is invalid" do
+      request = OpenStruct.new(env: {"HTTP_ACCEPT_LANGUAGE" => 'es_AR'})
       refute browser_locale(request)
     end
   end

--- a/tools/backend_tests
+++ b/tools/backend_tests
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose -f docker-compose.test.backend.yml up --exit-code-from web_test
+docker-compose -f docker-compose.test.backend.yml up --exit-code-from web_test $@


### PR DESCRIPTION
As per title.
It seems that there were still parsing errors unhandled by the new version of http-accept (it just raises parsing errors if the spec is not right).