### PR TITLE
Set a default logger for all apps

### DIFF
--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -20,8 +20,6 @@ class Api < App
     :entitystore => CACHE_CLIENT,
     :private_headers => []
 
-  enable :logging
-
   before do
     cache_control :no_cache
   end

--- a/api/app/controllers/data_app.rb
+++ b/api/app/controllers/data_app.rb
@@ -8,8 +8,6 @@ class DataApp < App
     :entitystore => CACHE_CLIENT,
     :private_headers => []
 
-  enable :logging
-
   before do
     cache_control :no_cache
   end

--- a/api/app/controllers/user_app.rb
+++ b/api/app/controllers/user_app.rb
@@ -7,8 +7,6 @@ class UserApp < App
     :entitystore => CACHE_CLIENT,
     :private_headers => []
 
-  enable :logging
-
   before do
     cache_control :no_cache
   end

--- a/api/config/app.rb
+++ b/api/config/app.rb
@@ -1,3 +1,5 @@
 class App < Sinatra::Base
   use Rack::Deflater
+
+  enable :logging
 end


### PR DESCRIPTION
As per title.
Before this PR, `logger' wasn't properly set up in many apps, so logging was not working.