### PR TITLE
Fix issues with lines url names

### DIFF
--- a/api/app/models/lines.rb
+++ b/api/app/models/lines.rb
@@ -15,7 +15,7 @@ class Line < Sequel::Model(:lines)
   many_to_many :stations, join_table: :station_lines
 
   def generate_url_name
-    self.url_name = "#{self.id}-#{self.name.strip.accentless.gsub(/\s|\//,'-').downcase}"
+    self.url_name = "#{self.id}-#{self.name.strip.accentless.gsub(/\s|\.|,|\//,'-').downcase}"
   end
 
   def remove_from_feature(feature)

--- a/api/test/unit/models/lines.rb
+++ b/api/test/unit/models/lines.rb
@@ -18,11 +18,11 @@ describe Line do
   it "should set the right url_name" do
     assert_equal 'test-line', @line.url_name
 
-    @line.name = " A New Name / Blah "
+    @line.name = " A New Name / Blah ,Pipo."
     @line.save
     @line.generate_url_name
 
-    assert_equal "#{@line.id}-a-new-name---blah", @line.url_name
+    assert_equal "#{@line.id}-a-new-name---blah--pipo-", @line.url_name
   end
 
   it "should return the right values" do

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -3,12 +3,12 @@ import Translate from 'react-translate-component';
 
 class FeatureLinesEditor extends PureComponent {
   onAddLine(e) {
-    const [line, line_url_name, system] = e.target.value.split(',');
+    const selectedOption = e.target.selectedOptions[0];
 
     const newLine = {
-      line: line,
-      line_url_name: line_url_name,
-      system: system
+      line: selectedOption.getAttribute('line-name'),
+      line_url_name: selectedOption.getAttribute('line-url-name'),
+      system: selectedOption.getAttribute('system-name'),
     }
 
     this.props.onAddLine(newLine);
@@ -49,7 +49,11 @@ class FeatureLinesEditor extends PureComponent {
           <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>
             <Translate component="option" content="editor.feature_viewer.add_line"/>
             {this.remainingLines().map(l =>
-              <option key={l.line.url_name} value={`${l.line.name},${l.line.url_name},${l.system.name}`}>{l.label}</option>
+              <option key={l.line.url_name}
+                      line-name={l.line.name}
+                      line-url-name={l.line.url_name}
+                      system-name={l.system.name}
+              >{l.label}</option>
             )}
           </select>
         </li>


### PR DESCRIPTION
- The lines editor in the feature viewer didn't work well with lines with commas in the name
- Drop support for commas in lines url names

After the deploy, run:
```ruby
lines = Line.where(Sequel.ilike(:url_name, '%,%')).all
# And update the url_names of these lines
```