### PR TITLE
Speed control: refresh speed only on mouse or key up events

### DIFF
--- a/client/src/components/city/timeline-speed-control.js
+++ b/client/src/components/city/timeline-speed-control.js
@@ -26,8 +26,9 @@ class TimelineSpeedControl extends PureComponent {
           className="c-range"
           min={this.minSpeed}
           max={this.maxSpeed}
-          value={this.speed()}
-          onChange={this.handleSpeedChange.bind(this)}
+          defaultValue={this.speed()}
+          onKeyUp={this.handleSpeedChange.bind(this)}
+          onMouseUp={this.handleSpeedChange.bind(this)}
         />
       </div>
     )


### PR DESCRIPTION
Before this PR, the speed was refreshed every time the slider value was modified. This led to, in certain cases, a history push error. This PR fixes this by updating the speed only when the `mouseUp` or `keyUp` events are triggered.

Fixes #292